### PR TITLE
EN-42: validation on End Date in contracts forms

### DIFF
--- a/src/components/forms/CreateForm.jsx
+++ b/src/components/forms/CreateForm.jsx
@@ -22,6 +22,14 @@ const CreateForm = ({ formData, title, resource }) => {
     }    
 };
 
+const validateEntity = async (values) => {
+  const errors = {};
+  if(values.endDate < values.startDate){
+    errors.endDate = "End Date can't be previous to Start Date";
+  }
+  return errors;
+}
+
   return (
     <Box m="10px">
       <Box display="flex" justifyContent="space-between" alignItems="center">
@@ -29,7 +37,7 @@ const CreateForm = ({ formData, title, resource }) => {
       </Box>
 
       <Create mutationOptions={{ onSuccess }}>
-        <SimpleForm>
+        <SimpleForm validate={validateEntity}>
           <Box width="100%">
             {formData.map((item, index) => {
               return (

--- a/src/components/forms/CreateForm.jsx
+++ b/src/components/forms/CreateForm.jsx
@@ -24,7 +24,7 @@ const CreateForm = ({ formData, title, resource }) => {
 
 const validateEntity = async (values) => {
   const errors = {};
-  if(values.endDate < values.startDate){
+  if(values.endDate < values.startDate && values.endDate != null){
     errors.endDate = "End Date can't be previous to Start Date";
   }
   return errors;

--- a/src/components/forms/CreateForm.jsx
+++ b/src/components/forms/CreateForm.jsx
@@ -24,7 +24,7 @@ const CreateForm = ({ formData, title, resource }) => {
 
 const validateEntity = async (values) => {
   const errors = {};
-  if(values.endDate < values.startDate && values.endDate != null){
+  if(values.endDate < values.startDate && values.endDate){
     errors.endDate = "End Date can't be previous to Start Date";
   }
   return errors;

--- a/src/components/forms/EditForm.jsx
+++ b/src/components/forms/EditForm.jsx
@@ -4,6 +4,15 @@ import Header from "../Header";
 import FormSection from "./FormSections";
 
 const EditForm = ({ formData, title }) => {
+
+const validateEntity = async (values) => {
+  const errors = {};
+  if(values.endDate < values.startDate){
+    errors.endDate = "End Date can't be previous to Start Date";
+  }
+  return errors;
+}
+
   return (
     <Box m="10px">
       <Box display="flex" justifyContent="space-between" alignItems="center">
@@ -11,7 +20,7 @@ const EditForm = ({ formData, title }) => {
       </Box>
 
       <Edit redirect="list">
-        <SimpleForm>
+        <SimpleForm validate={validateEntity}>
           <Box width="100%">
             {formData.map((item, index) => {
               return (

--- a/src/components/forms/EditForm.jsx
+++ b/src/components/forms/EditForm.jsx
@@ -8,7 +8,7 @@ const EditForm = ({ formData, title }) => {
 const validateEntity = async (values) => {
   const errors = {};
   if(values.endDate < values.startDate && values.endDate != null){
-   // errors.endDate = "End Date can't be previous to Start Date";
+    errors.endDate = "End Date can't be previous to Start Date";
   }
   return errors;
 }

--- a/src/components/forms/EditForm.jsx
+++ b/src/components/forms/EditForm.jsx
@@ -7,8 +7,8 @@ const EditForm = ({ formData, title }) => {
 
 const validateEntity = async (values) => {
   const errors = {};
-  if(values.endDate < values.startDate){
-    errors.endDate = "End Date can't be previous to Start Date";
+  if(values.endDate < values.startDate && values.endDate != null){
+   // errors.endDate = "End Date can't be previous to Start Date";
   }
   return errors;
 }

--- a/src/components/forms/EditForm.jsx
+++ b/src/components/forms/EditForm.jsx
@@ -7,7 +7,7 @@ const EditForm = ({ formData, title }) => {
 
 const validateEntity = async (values) => {
   const errors = {};
-  if(values.endDate < values.startDate && values.endDate != null){
+  if(values.endDate < values.startDate && values.endDate){
     errors.endDate = "End Date can't be previous to Start Date";
   }
   return errors;


### PR DESCRIPTION
# Description :pencil:

During a create or edit contract, the field end date cant be previous to start date.

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-42

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

if end date is previous to start date, an error message is displayed and the field is remarked with the message "End Date can't be previous to Start Date".

![image](https://user-images.githubusercontent.com/70980835/210866121-40d52492-bc34-44cf-86f5-b697fcadd8f6.png)

![image](https://user-images.githubusercontent.com/70980835/210865295-9ff918b0-219e-4e7a-8c25-0fc903b01c45.png)


