### PR TITLE
EN-65: technologies and profile bug fix

### DIFF
--- a/src/components/forms/MultiSelectInput.jsx
+++ b/src/components/forms/MultiSelectInput.jsx
@@ -8,7 +8,7 @@ const ReferenceSelectArrayInputItem = ({ referenceValues }) => {
       {
         referenceValues && (
         <ReferenceArrayInput reference={reference} source={source}>
-            <SelectArrayInput fullWidth>
+            <SelectArrayInput fullWidth defaultValue={[]}>
                 <ChipField source={source} />
             </SelectArrayInput>
         </ReferenceArrayInput>


### PR DESCRIPTION
# Description :pencil:

Employee form now allows the empty technology and profile field

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-65

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

Employee form with empty technologies and profile
![image](https://user-images.githubusercontent.com/70980835/218137698-7f975338-18e3-4eec-9847-6c25a23c68ae.png)

Request
![image](https://user-images.githubusercontent.com/70980835/218138099-a3e34006-1925-4c0a-bf93-7250d53a669e.png)

New employee created
![image](https://user-images.githubusercontent.com/70980835/218138271-41bcf7fe-dd78-43fc-ab70-9929f4c640a7.png)

