### PR TITLE
EN-39: Contract/Assignment form open from Employee must have Employee and Company pre filled and should not be editable

### DIFF
--- a/src/assignments.js
+++ b/src/assignments.js
@@ -12,16 +12,7 @@ import {
 import CreateForm from "./components/forms/CreateForm";
 import EditForm from "./components/forms/EditForm";
 
-function getDisabledValue(record) {
-  let isDisabled;
-  if (record != null) {
-    record.source === "employeeProfile"
-      ? (isDisabled = true)
-      : (isDisabled = false);
-    return isDisabled;
-  }
-  return false;
-}
+function disabledCheck(source) { return source === "employeeProfile"; }
 
 const formData = [
   {
@@ -36,7 +27,7 @@ const formData = [
           optionText: null,
           multiselect: false,
           required: true,
-          check: getDisabledValue,
+          disabledCheck: disabledCheck,
         },
       },
       { name: "startDate", type: "date", required: true },

--- a/src/assignments.js
+++ b/src/assignments.js
@@ -12,6 +12,17 @@ import {
 import CreateForm from "./components/forms/CreateForm";
 import EditForm from "./components/forms/EditForm";
 
+function getDisabledValue(record) {
+  let isDisabled;
+  if (record != null) {
+    record.source === "employeeProfile"
+      ? (isDisabled = true)
+      : (isDisabled = false);
+    return isDisabled;
+  }
+  return false;
+}
+
 const formData = [
   {
     title: "Employee",
@@ -25,6 +36,7 @@ const formData = [
           optionText: null,
           multiselect: false,
           required: true,
+          check: getDisabledValue,
         },
       },
       { name: "startDate", type: "date", required: true },
@@ -86,7 +98,7 @@ const formData = [
           reference: "seniorities",
           optionText: "name",
           multiselect: false,
-          required: true
+          required: true,
         },
       },
     ],

--- a/src/components/RedirectButton.jsx
+++ b/src/components/RedirectButton.jsx
@@ -1,12 +1,22 @@
-import { Button } from '@mui/material';
-import { useRedirect } from 'react-admin';
+import { Button } from "@mui/material";
+import { useRedirect } from "react-admin";
 
-const RedirectButton = ({ form, resource, text }) => {
-    const redirect = useRedirect();
-    const handleClick = () => {
-        redirect(form,resource);
-    }
-    return <Button variant="text" onClick={handleClick} >{text}</Button>;
+const RedirectButton = ({ form, resource, text, recordId }) => {
+  const redirect = useRedirect();
+  const handleClick = () => {
+    redirect(
+      form,
+      resource,
+      1,
+      {},
+      { record: { employeeId: recordId, source: "employeeProfile" } }
+    );
+  };
+  return (
+    <Button variant="text" onClick={handleClick}>
+      {text}
+    </Button>
+  );
 };
 
 export default RedirectButton;

--- a/src/components/RedirectButton.jsx
+++ b/src/components/RedirectButton.jsx
@@ -1,16 +1,10 @@
 import { Button } from "@mui/material";
 import { useRedirect } from "react-admin";
 
-const RedirectButton = ({ form, resource, text, recordId }) => {
+const RedirectButton = ({ form, resource, text, recordId, source }) => {
   const redirect = useRedirect();
   const handleClick = () => {
-    redirect(
-      form,
-      resource,
-      1,
-      {},
-      { record: { employeeId: recordId, source: "employeeProfile" } }
-    );
+    redirect(form, resource, 1, {}, { record: { employeeId: recordId, source: source } });
   };
   return (
     <Button variant="text" onClick={handleClick}>

--- a/src/components/forms/FormSections.jsx
+++ b/src/components/forms/FormSections.jsx
@@ -4,11 +4,7 @@ import ReferenceInputItem from "./ReferenceInputItem";
 import PaymentSection from "./PaymentSection";
 import MultiSelectInput from "./MultiSelectInput";
 
-const FormSection = ({
-  formSectionTitle,
-  inputsList,
-  customSections,
-}) => {
+const FormSection = ({ formSectionTitle, inputsList, customSections }) => {
   const isNonMobile = useMediaQuery("(min-width:600px)");
   return (
     <Box>

--- a/src/components/forms/ReferenceInputItem.jsx
+++ b/src/components/forms/ReferenceInputItem.jsx
@@ -1,13 +1,21 @@
 import * as React from "react";
-import { ReferenceInput, SelectInput } from "react-admin";
+import { ReferenceInput, SelectInput, useRecordContext } from "react-admin";
 
 const ReferenceInputItem = ({ referenceValues }) => {
-  const { source, reference, optionText, required } = referenceValues;
+  const { source, reference, optionText, required, check } = referenceValues;
+  const record = useRecordContext();
+  var setDisabled = false;
+  if (check !== undefined) setDisabled = check(record);
   return (
     <>
       {referenceValues && (
         <ReferenceInput source={source} reference={reference}>
-          <SelectInput optionText={optionText} required={required} fullWidth />
+          <SelectInput
+            optionText={optionText}
+            required={required}
+            disabled={setDisabled}
+            fullWidth
+          />
         </ReferenceInput>
       )}
     </>

--- a/src/components/forms/ReferenceInputItem.jsx
+++ b/src/components/forms/ReferenceInputItem.jsx
@@ -2,10 +2,12 @@ import * as React from "react";
 import { ReferenceInput, SelectInput, useRecordContext } from "react-admin";
 
 const ReferenceInputItem = ({ referenceValues }) => {
-  const { source, reference, optionText, required, check } = referenceValues;
+  const { source, reference, optionText, required, disabledCheck } = referenceValues;
   const record = useRecordContext();
   var setDisabled = false;
-  if (check !== undefined) setDisabled = check(record);
+  if (disabledCheck !== undefined && record !== undefined) {
+    setDisabled = disabledCheck(record.source);
+   }
   return (
     <>
       {referenceValues && (

--- a/src/components/forms/ReferenceInputItem.jsx
+++ b/src/components/forms/ReferenceInputItem.jsx
@@ -12,7 +12,7 @@ const ReferenceInputItem = ({ referenceValues }) => {
     <>
       {referenceValues && (
         <ReferenceInput source={source} reference={reference} perPage={100}>
-          <SelectInput optionText={optionText} required={required} fullWidth />
+          <SelectInput optionText={optionText} required={required} disabled={setDisabled} fullWidth />
         </ReferenceInput>
       )}
     </>

--- a/src/contracts.js
+++ b/src/contracts.js
@@ -13,16 +13,7 @@ import {
 import CreateForm from "./components/forms/CreateForm";
 import EditForm from "./components/forms/EditForm";
 
-function getDisabledValue(record) {
-  let isDisabled;
-  if (record != null) {
-    record.source === "employeeProfile"
-      ? (isDisabled = true)
-      : (isDisabled = false);
-    return isDisabled;
-  }
-  return false;
-}
+function disabledCheck(source) { return source === "employeeProfile"; }
 
 const formData = [
   {
@@ -64,7 +55,7 @@ const formData = [
           optionText: null,
           multiselect: false,
           required: true,
-          check: getDisabledValue,
+          disabledCheck: disabledCheck,
         },
       },
       { name: "startDate", type: "date", required: true },

--- a/src/contracts.js
+++ b/src/contracts.js
@@ -13,6 +13,17 @@ import {
 import CreateForm from "./components/forms/CreateForm";
 import EditForm from "./components/forms/EditForm";
 
+function getDisabledValue(record) {
+  let isDisabled;
+  if (record != null) {
+    record.source === "employeeProfile"
+      ? (isDisabled = true)
+      : (isDisabled = false);
+    return isDisabled;
+  }
+  return false;
+}
+
 const formData = [
   {
     title: "Company",
@@ -53,6 +64,7 @@ const formData = [
           optionText: null,
           multiselect: false,
           required: true,
+          check: getDisabledValue,
         },
       },
       { name: "startDate", type: "date", required: true },

--- a/src/employees.js
+++ b/src/employees.js
@@ -287,6 +287,7 @@ export const EmployeeProfile = () => (
               resource="contracts"
               text="+ CREATE"
               recordId={DisplayRecordCurrentId()}
+              source="employeeProfile"
             />
           )}
           <Datagrid rowStyle={activeContractRowStyle}>
@@ -337,6 +338,7 @@ export const EmployeeProfile = () => (
               resource="assignments"
               text="+ CREATE"
               recordId={DisplayRecordCurrentId()}
+              source="employeeProfile"
             />
           )}
           <Datagrid>

--- a/src/employees.js
+++ b/src/employees.js
@@ -24,6 +24,7 @@ import {
   ReferenceField,
   NumberField,
   SearchInput,
+  useGetRecordId,
 } from "react-admin";
 import {
   Card,
@@ -44,6 +45,10 @@ const COLOR_white = "#white";
 const activeContractRowStyle = (record) => ({
   backgroundColor: record.active === true ? COLOR_green : COLOR_white,
 });
+
+const DisplayRecordCurrentId = () => {
+  return useGetRecordId();
+};
 
 const formData = [
   {
@@ -270,15 +275,20 @@ export const EmployeeProfile = () => (
         </ArrayField>
       </Tab>
       <Tab label="Contracts">
-        {HasPermissions("contracts", "create") && (
-          <RedirectButton form="create" resource="contracts" text="+ CREATE" />
-        )}
         <ReferenceManyField
-          label="Contracts"
+          label=""
           reference="contracts"
           target="employeeId"
           sort={{ field: "startDate", order: "DESC" }}
         >
+          {HasPermissions("contracts", "create") && (
+            <RedirectButton
+              form="create"
+              resource="contracts"
+              text="+ CREATE"
+              recordId={DisplayRecordCurrentId()}
+            />
+          )}
           <Datagrid rowStyle={activeContractRowStyle}>
             <ReferenceField
               source="contractType"
@@ -315,19 +325,20 @@ export const EmployeeProfile = () => (
         </ReferenceManyField>
       </Tab>
       <Tab label="Assigments">
-        {HasPermissions("assignments", "create") && (
-          <RedirectButton
-            form="create"
-            resource="assignments"
-            text="+ CREATE"
-          />
-        )}
         <ReferenceManyField
           label="Assignments"
           reference="assignments"
           target="employeeId"
           sort={{ field: "startDate", order: "DESC" }}
         >
+          {HasPermissions("assignments", "create") && (
+            <RedirectButton
+              form="create"
+              resource="assignments"
+              text="+ CREATE"
+              recordId={DisplayRecordCurrentId()}
+            />
+          )}
           <Datagrid>
             <ReferenceField source="projectId" reference="projects">
               <TextField source="name" />


### PR DESCRIPTION
# Description :pencil:
when redirected from employee profile to contract and assignment, the employee is pre filled and not editable

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-39

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

Manual testing
employee profile
![image](https://user-images.githubusercontent.com/70980835/225341618-1fe50f12-60a4-4c1e-8afc-edc18ca1f1e4.png)

contract form
![image](https://user-images.githubusercontent.com/70980835/225341801-5835aa7b-754d-449a-a4e1-cbe6677b7676.png)

same to assignment form
![image](https://user-images.githubusercontent.com/70980835/225341982-1ecd8c71-a758-4889-88fc-73315286078d.png)


