### PR TITLE
EN-72: Contract status based on Due date

### DIFF
--- a/src/components/forms/CreateForm.jsx
+++ b/src/components/forms/CreateForm.jsx
@@ -24,8 +24,8 @@ const CreateForm = ({ formData, title, resource }) => {
 
 const validateEntity = async (values) => {
   const errors = {};
-  if(values.endDate < values.startDate && values.endDate){
-    errors.endDate = "End Date can't be previous to Start Date";
+  if(values.endDate <= values.startDate && values.endDate){
+    errors.endDate = "End Date can't be previous or equals to Start Date";
   }
   return errors;
 }

--- a/src/components/forms/EditForm.jsx
+++ b/src/components/forms/EditForm.jsx
@@ -8,7 +8,7 @@ const EditForm = ({ formData, title }) => {
 const validateEntity = async (values) => {
   const errors = {};
   if(values.endDate <= values.startDate && values.endDate){
-    errors.endDate = "End Date can't be previous to Start Date";
+    errors.endDate = "End Date can't be previous or equals to Start Date";
   }
   return errors;
 }

--- a/src/components/forms/EditForm.jsx
+++ b/src/components/forms/EditForm.jsx
@@ -7,7 +7,7 @@ const EditForm = ({ formData, title }) => {
 
 const validateEntity = async (values) => {
   const errors = {};
-  if(values.endDate < values.startDate && values.endDate){
+  if(values.endDate <= values.startDate && values.endDate){
     errors.endDate = "End Date can't be previous to Start Date";
   }
   return errors;


### PR DESCRIPTION
# Description :pencil:

The contract status now is based on due date. A end date can't be previous or equals to start date.

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-72

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

Manual testing
![image](https://user-images.githubusercontent.com/70980835/228852072-01c60347-96b9-41b6-a681-72611e32e1e6.png)

