### PR TITLE
EN-76: Prefill new contract/assignment with active information

### DIFF
--- a/src/components/RedirectButton.jsx
+++ b/src/components/RedirectButton.jsx
@@ -1,10 +1,47 @@
 import { Button } from "@mui/material";
 import { useRedirect } from "react-admin";
 
-const RedirectButton = ({ form, resource, text, recordId, source }) => {
+const RedirectButton = ({ form, resource, text, recordId, record, source }) => {
+  let recordToDisplay;
   const redirect = useRedirect();
   const handleClick = () => {
-    redirect(form, resource, 1, {}, { record: { employeeId: recordId, source: source } });
+    if (record !== undefined && resource === "contracts") {
+      recordToDisplay = {
+        employeeId: recordId,
+        companyId: record.companyId,
+        contractType: record.contractType,
+        startDate: record.startDate,
+        endDate: record.endDate,
+        roleId: record.roleId,
+        seniorityId: record.seniorityId,
+        hoursPerMonth: record.hoursPerMonth,
+        vacations: record.vacations,
+        benefits: record.benefits,
+        paymentSettlement: record.paymentSettlement,
+        notes: record.notes,
+        source: source,
+      };
+    } else if (record !== undefined && resource === "assignments") {
+      recordToDisplay = {
+        employeeId: recordId,
+        billableRate: record.billableRate,
+        currency: record.currency,
+        startDate: record.startDate,
+        hoursPerMonth: record.hoursPerMonth,
+        endDate: record.endDate,
+        labourHours: record.labourHours,
+        projectId: record.projectId,
+        roleId: record.roleId,
+        seniorityId: record.seniorityId,
+        source: source,
+      };
+    } else {
+      recordToDisplay = {
+        employeeId: recordId,
+        source: source,
+      };
+    }
+    redirect(form, resource, 1, {}, { record: recordToDisplay });
   };
   return (
     <Button variant="text" onClick={handleClick}>

--- a/src/components/RedirectButton.jsx
+++ b/src/components/RedirectButton.jsx
@@ -21,7 +21,7 @@ const RedirectButton = ({ form, resource, text, recordId, record, source }) => {
         notes: record.notes,
         source: source,
       };
-    } else if (record !== null && resource === "assignments") {
+    } else if (record !== undefined && resource === "assignments") {
       recordToDisplay = {
         employeeId: recordId,
         billableRate: record.billableRate,

--- a/src/components/RedirectButton.jsx
+++ b/src/components/RedirectButton.jsx
@@ -21,7 +21,7 @@ const RedirectButton = ({ form, resource, text, recordId, record, source }) => {
         notes: record.notes,
         source: source,
       };
-    } else if (record !== undefined && resource === "assignments") {
+    } else if (record !== null && resource === "assignments") {
       recordToDisplay = {
         employeeId: recordId,
         billableRate: record.billableRate,

--- a/src/employeeProfiles.js
+++ b/src/employeeProfiles.js
@@ -18,6 +18,7 @@ import {
   NumberField,
   useGetRecordId,
   useGetManyReference,
+  useGetOne,
 } from "react-admin";
 import { Avatar, Box, Divider, Grid } from "@mui/material";
 import RedirectButton from "./components/RedirectButton";
@@ -48,11 +49,8 @@ const GetActiveContract = () => {
 
 const GetLatestAssignment = () => {
   const employeeId = useGetRecordId();
-  const { data } = useGetManyReference("assignments", {
-    target: "employeeId",
-    id: employeeId,
-  });
-  return data !== undefined ? data.find((a) => a.endDate === null) : null;
+  const { data: employee } = useGetOne('employees', { id: employeeId });
+  return employee.lastAssignment;
 };
 
 export const EmployeeProfile = () => (

--- a/src/employeeProfiles.js
+++ b/src/employeeProfiles.js
@@ -17,6 +17,7 @@ import {
   ReferenceField,
   NumberField,
   useGetRecordId,
+  useGetManyReference,
 } from "react-admin";
 import { Avatar, Box, Divider, Grid } from "@mui/material";
 import RedirectButton from "./components/RedirectButton";
@@ -31,6 +32,27 @@ const activeContractRowStyle = (record) => ({
 
 const DisplayRecordCurrentId = () => {
   return useGetRecordId();
+};
+
+const GetActiveContract = () => {
+  const employeeId = useGetRecordId();
+  const { data } = useGetManyReference("contracts", {
+    target: "employeeId",
+    id: employeeId,
+    filter: {
+      active: true,
+    },
+  });
+  return data !== undefined ? data.at(0) : null;
+};
+
+const GetLatestAssignment = () => {
+  const employeeId = useGetRecordId();
+  const { data } = useGetManyReference("assignments", {
+    target: "employeeId",
+    id: employeeId,
+  });
+  return data !== undefined ? data.find((a) => a.endDate === null) : null;
 };
 
 export const EmployeeProfile = () => (
@@ -141,6 +163,7 @@ export const EmployeeProfile = () => (
               resource="contracts"
               text="+ CREATE"
               recordId={DisplayRecordCurrentId()}
+              record={GetActiveContract()}
               source="employeeProfile"
             />
           )}
@@ -192,6 +215,7 @@ export const EmployeeProfile = () => (
               resource="assignments"
               text="+ CREATE"
               recordId={DisplayRecordCurrentId()}
+              record={GetLatestAssignment()}
               source="employeeProfile"
             />
           )}

--- a/src/employeeProfiles.js
+++ b/src/employeeProfiles.js
@@ -37,6 +37,7 @@ const DisplayRecordCurrentId = () => {
 
 const GetActiveContract = () => {
   const employeeId = useGetRecordId();
+
   const { data } = useGetManyReference("contracts", {
     target: "employeeId",
     id: employeeId,
@@ -44,13 +45,35 @@ const GetActiveContract = () => {
       active: true,
     },
   });
-  return data !== undefined ? data.at(0) : null;
+
+  const activeContract = React.useMemo(() => {
+    if (Array.isArray(data)) {
+      return data[0];
+    }
+    return undefined;
+  }, [data]);
+
+  return activeContract;
 };
 
 const GetLatestAssignment = () => {
   const employeeId = useGetRecordId();
-  const { data: employee } = useGetOne('employees', { id: employeeId });
-  return employee.lastAssignment;
+
+  const { data: employee } = useGetOne("employees", { id: employeeId });
+
+  const { data: assignments } = useGetManyReference("assignments", {
+    target: "employeeId",
+    id: employeeId,
+  });
+
+  const latestAssignment = React.useMemo(() => {
+    if (Array.isArray(assignments)) {
+      return assignments.find((a) => a.id === employee.lastAssignmentId);
+    }
+    return undefined;
+  }, [assignments, employee]);
+
+  return latestAssignment;
 };
 
 export const EmployeeProfile = () => (

--- a/src/employeeProfiles.js
+++ b/src/employeeProfiles.js
@@ -65,6 +65,8 @@ const GetLatestAssignment = () => {
     target: "employeeId",
     id: employeeId,
   });
+  // It will be changed when the active field is added to assignments
+
 
   const latestAssignment = React.useMemo(() => {
     if (Array.isArray(assignments)) {


### PR DESCRIPTION
# Description :pencil:

When a new contract/employee is created from employees profile, the latest active information is prefill in the form.

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-76

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

Manual testing
New contract prefill with information from active contract
![image](https://user-images.githubusercontent.com/70980835/233380641-b8c5ea45-9bdc-4889-aec7-d20e734c573b.png)

New contract prefill from employee without active contract
![image](https://user-images.githubusercontent.com/70980835/233381115-670e1b49-a4ac-4a0e-864e-94d902211246.png)

New assignment prefill with information from latest employee assignment
![image](https://user-images.githubusercontent.com/70980835/233381704-2237fd94-81ac-43b9-8015-faa452ecf79d.png)

New assignment from employee without assignment
![image](https://user-images.githubusercontent.com/70980835/233381357-963a7cbc-2d62-48b7-b898-0d908056032a.png)



