### PR TITLE
EN-86: Display client and proyect in assignments

### DIFF
--- a/src/assignments.js
+++ b/src/assignments.js
@@ -107,6 +107,14 @@ export const AssignmentList = () => {
           <TextField source="lastName" /> <TextField source="firstName" />
         </WrapperField>
       </ReferenceField>
+      <ReferenceField source="projectId" reference="projects">
+        <TextField source="name" />
+      </ReferenceField>
+      <ReferenceField source="projectId" reference="projects" label="Client">
+        <ReferenceField source="clientId" reference="clients">
+          <TextField source="name" />
+        </ReferenceField>
+      </ReferenceField>
       <DateField source="startDate" locales={locale} />
       <DateField source="endDate" locales={locale} />
       <ReferenceField source="roleId" reference="roles">

--- a/src/employeeProfiles.js
+++ b/src/employeeProfiles.js
@@ -184,7 +184,7 @@ export const EmployeeProfile = () => {
       </Tab>
       <Tab label="Assigments">
         <ReferenceManyField
-          label="Assignments"
+          label=""
           reference="assignments"
           target="employeeId"
           sort={{ field: "startDate", order: "DESC" }}
@@ -201,6 +201,11 @@ export const EmployeeProfile = () => {
           <Datagrid>
             <ReferenceField source="projectId" reference="projects">
               <TextField source="name" />
+            </ReferenceField>
+            <ReferenceField source="projectId" reference="projects" label="Client">
+              <ReferenceField source="clientId" reference="clients">
+                <TextField source="name" />
+              </ReferenceField>
             </ReferenceField>
             <DateField source="startDate" locales={locale}/>
             <DateField source="endDate" locales={locale}/>


### PR DESCRIPTION
# Description :pencil:

Now client and project are displayed in assignments list

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-86

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

Assignments list:
![image](https://user-images.githubusercontent.com/70980835/234626206-9fb807bd-d0b7-43b0-bcac-aa7c6a271b26.png)

Assignments in employee profile:
![image](https://user-images.githubusercontent.com/70980835/234626351-b183db11-2eab-445c-8ae3-7d2bd96b628c.png)


