### PR TITLE
EN-90: align employee list with cvs export

### DIFF
--- a/src/employees.js
+++ b/src/employees.js
@@ -13,6 +13,7 @@ import {
   useListContext,
   SearchInput,
   useLocaleState,
+  downloadCSV,
 } from "react-admin";
 import {
   Card,
@@ -40,6 +41,7 @@ import { HasPermissions } from "./components/layout/CustomActions";
 import RowRadioButtonGroup from "./components/buttons/RowRadioButtonGroup";
 import { useState } from "react";
 import { Link } from "react-router-dom";
+import jsonExport from "jsonexport/dist";
 
 const COLOR_BG = [
   red[500],
@@ -121,6 +123,33 @@ const formData = [
 
 const employeeFilters = [<SearchInput source="q" alwaysOn />];
 
+const exporter = (employees) => {
+  const employeesForExport = employees.map((employee) => {
+    return fieldsList.reduce((acc, field) => {
+      return { ...acc, [field]: employee[field] }; // align list fields to export with employee fields list
+    }, {});
+  });
+
+  jsonExport(
+    employeesForExport,
+    (err, csv) => {
+      downloadCSV(csv, "employees"); // download as 'employees.csv` file
+    }
+  );
+};
+
+const fieldsList = [
+  "firstName",
+  "lastName",
+  "personalEmail",
+  "startDate",
+  "city",
+  "country",
+  "client",
+  "project",
+  "role",
+];
+
 export const EmployeeList = () => {
   const [viewOptionValue, setRadioValue] = useState("card");
 
@@ -147,6 +176,7 @@ export const EmployeeList = () => {
       component="div"
       actions={false}
       filters={employeeFilters}
+      exporter={exporter}
     >
       <>
         <TopToolbar
@@ -255,16 +285,9 @@ const EmployeeInformation = ({ renderAs = "list" }) => {
   } else {
     return (
       <Datagrid rowClick="show">
-        <TextField source="internalId" />
-        <TextField source="firstName" />
-        <TextField source="lastName" />
-        <TextField source="personalEmail" />
-        <DateField source="startDate" locales={locale} />
-        <TextField source="city" />
-        <TextField source="country" />
-        <TextField source="client" />
-        <TextField source="project" />
-        <TextField source="role" />
+        {fieldsList.map((field) => (
+          <TextField source={field} />
+        ))}
         <ShowButton />
         {HasPermissions("employees", "update") && <EditButton />}
       </Datagrid>


### PR DESCRIPTION
# Description :pencil:

Now employee list is aligned with cvs export.

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-90

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

Employee list
![image](https://user-images.githubusercontent.com/70980835/235731089-11c694b2-e483-44fa-9ea5-0a7825d0b487.png)

CVS export
![image](https://user-images.githubusercontent.com/70980835/235731271-0fcbdf42-47d5-4f96-92bf-01f282e998fc.png)


