### PR TITLE
[EN-75] Re order fields in Employee profile

### DIFF
--- a/src/employeeProfiles.js
+++ b/src/employeeProfiles.js
@@ -37,37 +37,37 @@ const DisplayRecordCurrentId = () => {
 export const EmployeeProfile = () => {
   const [locale] = useLocaleState();
   return (
-  <Show
-    title="Show employee"
-    actions={<ListActions entity={"employees"} />}
-    emptyWhileLoading
-  >
-    <Grid
-      container
-      direction="row"
-      justifyContent="flex-start"
-      alignItems="center"
+    <Show
+      title="Show employee"
+      actions={<ListActions entity={"employees"} />}
+      emptyWhileLoading
     >
-      <Grid item>
-        <Box m={2}>
-          {/*Profile image hardcoded until photo upload feature is in palce*/}
-          <Avatar
-            alt="Employee"
-            src="https://entropay-assets.s3.amazonaws.com/default-profile.png"
-            sx={{ width: 100, height: 100 }}
-          />
-        </Box>
-      </Grid>
-      <Grid item>
-        <SimpleShowLayout divider={<Divider flexItem />}>
-          <FunctionField
-            label=""
-            render={(record) => `${record.firstName} ${record.lastName}`}
-          />
-          <TextField label="" source="personalEmail" />
-        </SimpleShowLayout>
-      </Grid>
-      {/*
+      <Grid
+        container
+        direction="row"
+        justifyContent="flex-start"
+        alignItems="center"
+      >
+        <Grid item>
+          <Box m={2}>
+            {/*Profile image hardcoded until photo upload feature is in palce*/}
+            <Avatar
+              alt="Employee"
+              src="https://entropay-assets.s3.amazonaws.com/default-profile.png"
+              sx={{ width: 100, height: 100 }}
+            />
+          </Box>
+        </Grid>
+        <Grid item>
+          <SimpleShowLayout divider={<Divider flexItem />}>
+            <FunctionField
+              label=""
+              render={(record) => `${record.firstName} ${record.lastName}`}
+            />
+            <TextField label="" source="personalEmail" />
+          </SimpleShowLayout>
+        </Grid>
+        {/*
       <Grid item>
         <SimpleShowLayout divider={<Divider flexItem />}>
           <TextField label="Current assigment" source="" />
@@ -76,154 +76,185 @@ export const EmployeeProfile = () => {
       </Grid>
       Hidden empty fields until developed
       */}
-    </Grid>
-    <TabbedShowLayout>
-      <Tab label="Personal and financial information">
-        <Grid
-          container
-          direction="row"
-          justifyContent="flex-start"
-          alignItems="flex-start"
-        >
-          <SimpleShowLayout divider={<Divider flexItem />}>
-            <TextField source="internalId" label="Internal ID" />
-            <TextField source="taxId" />
-            <TextField source="phoneNumber" />
-            <TextField source="mobileNumber" />
-            <TextField source="address" />
-            <TextField source="city" />
-            <TextField source="emergencyContactFullName" />
-            <TextField source="emergencyContactPhone" />
-            <TextField source="notes" />
-          </SimpleShowLayout>
-          <SimpleShowLayout divider={<Divider flexItem />}>
-            <TextField source="state" />
-            <TextField source="zip" />
-            <TextField source="country" />
-            <DateField source="birthDate" locales={locale}/>
-            <TextField source="personalNumber" />
-            <TextField source="healthInsurance" />
-            <ReferenceArrayField
-              label="Profile"
-              reference="roles"
-              source="profile"
+      </Grid>
+      <TabbedShowLayout>
+        <Tab label="Personal and financial information">
+          <Grid
+            container
+            direction="row"
+            justifyContent="flex-start"
+            alignItems="flex-start"
+          >
+            <Grid item xs={6}>
+              <SimpleShowLayout
+                divider={<Divider flexItem />}
+                sx={{
+                  "& .RaSimpleShowLayout-row": {
+                    minHeight: 65,
+                    maxHeight: 65,
+                    overflow: "auto",
+                  },
+                }}
+              >
+                <TextField source="internalId" label="Internal ID" />
+                <ReferenceArrayField
+                  label="Profile"
+                  reference="roles"
+                  source="profile"
+                >
+                  <SingleFieldList>
+                    <ChipField source="name" />
+                  </SingleFieldList>
+                </ReferenceArrayField>
+                <TextField source="phoneNumber" />
+                <DateField source="birthDate" locales={locale} />
+                <TextField source="taxId" />
+                <TextField source="address" />
+                <TextField source="city" />
+                <TextField source="country" />
+                <TextField source="notes" />
+              </SimpleShowLayout>
+            </Grid>
+
+            <Grid item xs={6}>
+              <SimpleShowLayout
+                divider={<Divider flexItem />}
+                sx={{
+                  "& .RaSimpleShowLayout-row": {
+                    minHeight: 65,
+                  },
+                }}
+              >
+                <ReferenceArrayField
+                  label="Technologies"
+                  reference="technologies"
+                  source="technologies"
+                >
+                  <SingleFieldList>
+                    <ChipField source="name" />
+                  </SingleFieldList>
+                </ReferenceArrayField>
+                <TextField source="labourEmail" />
+                <TextField source="mobileNumber" />
+                <TextField source="personalNumber" />
+                <TextField source="state" />
+                <TextField source="zip" />
+                <TextField source="emergencyContactFullName" />
+                <TextField source="healthInsurance" />
+                <TextField source="emergencyContactPhone" />
+              </SimpleShowLayout>
+            </Grid>
+          </Grid>
+          <ArrayField source="paymentInformation">
+            <Datagrid
+              bulkActionButtons={false}
+              sx={{
+                mb: 2,
+              }}
             >
-              <SingleFieldList>
+              <TextField source="platform" />
+              <TextField source="country" />
+              <TextField source="cbu" label="Alias/CBU" />
+            </Datagrid>
+          </ArrayField>
+        </Tab>
+        <Tab label="Contracts">
+          <ReferenceManyField
+            label=""
+            reference="contracts"
+            target="employeeId"
+            sort={{ field: "startDate", order: "DESC" }}
+          >
+            {HasPermissions("contracts", "create") && (
+              <RedirectButton
+                form="create"
+                resource="contracts"
+                text="+ CREATE"
+                recordId={DisplayRecordCurrentId()}
+                source="employeeProfile"
+              />
+            )}
+            <Datagrid rowStyle={activeContractRowStyle}>
+              <ReferenceField
+                source="contractType"
+                reference="contracts/contract-types"
+              >
+                <ChipField source="value" />
+              </ReferenceField>
+              <FunctionField
+                label="Status"
+                sortBy="active"
+                sortByOrder="ASC"
+                render={(record) =>
+                  record.active === true ? "Active" : "Inactive"
+                }
+              />
+              ;
+              <ReferenceField source="companyId" reference="companies">
+                <TextField source="name" />
+              </ReferenceField>
+              <DateField source="startDate" locales={locale} />
+              <DateField source="endDate" locales={locale} />
+              <ReferenceField source="roleId" reference="roles">
                 <ChipField source="name" />
-              </SingleFieldList>
-            </ReferenceArrayField>
-            <ReferenceArrayField
-              label="Technologies"
-              reference="technologies"
-              source="technologies"
-            >
-              <SingleFieldList>
+              </ReferenceField>
+              <ReferenceField source="seniorityId" reference="seniorities">
                 <ChipField source="name" />
-              </SingleFieldList>
-            </ReferenceArrayField>
-          </SimpleShowLayout>
-        </Grid>
-        <ArrayField source="paymentInformation">
-          <Datagrid>
-            <TextField source="platform" />
-            <TextField source="country" />
-            <TextField source="cbu" label="Alias/CBU" />
-          </Datagrid>
-        </ArrayField>
-      </Tab>
-      <Tab label="Contracts">
-        <ReferenceManyField
-          label=""
-          reference="contracts"
-          target="employeeId"
-          sort={{ field: "startDate", order: "DESC" }}
-        >
-          {HasPermissions("contracts", "create") && (
-            <RedirectButton
-              form="create"
-              resource="contracts"
-              text="+ CREATE"
-              recordId={DisplayRecordCurrentId()}
-              source="employeeProfile"
-            />
-          )}
-          <Datagrid rowStyle={activeContractRowStyle}>
-            <ReferenceField
-              source="contractType"
-              reference="contracts/contract-types"
-            >
-              <ChipField source="value" />
-            </ReferenceField>
-            <FunctionField
-              label="Status"
-              sortBy="active"
-              sortByOrder="ASC"
-              render={(record) =>
-                record.active === true ? "Active" : "Inactive"
-              }
-            />
-            ;
-            <ReferenceField source="companyId" reference="companies">
-              <TextField source="name" />
-            </ReferenceField>
-            <DateField source="startDate" locales={locale}/>
-            <DateField source="endDate" locales={locale}/>
-            <ReferenceField source="roleId" reference="roles">
-              <ChipField source="name" />
-            </ReferenceField>
-            <ReferenceField source="seniorityId" reference="seniorities">
-              <ChipField source="name" />
-            </ReferenceField>
-            <NumberField source="hoursPerMonth" />
-            <NumberField source="vacations" />
-            <TextField source="benefits" />
-            <TextField source="notes" />
-            {HasPermissions("contracts", "update") && <EditButton />}
-          </Datagrid>
-        </ReferenceManyField>
-      </Tab>
-      <Tab label="Assigments">
-        <ReferenceManyField
-          label="Assignments"
-          reference="assignments"
-          target="employeeId"
-          sort={{ field: "startDate", order: "DESC" }}
-        >
-          {HasPermissions("assignments", "create") && (
-            <RedirectButton
-              form="create"
-              resource="assignments"
-              text="+ CREATE"
-              recordId={DisplayRecordCurrentId()}
-              source="employeeProfile"
-            />
-          )}
-          <Datagrid>
-            <ReferenceField source="projectId" reference="projects">
-              <TextField source="name" />
-            </ReferenceField>
-            <DateField source="startDate" locales={locale}/>
-            <DateField source="endDate" locales={locale}/>
-            <ReferenceField source="roleId" reference="roles">
-              <ChipField source="name" />
-            </ReferenceField>
-            <NumberField source="hoursPerMonth" />
-            <TextField source="billableRate" />
-            <ReferenceField source="currency" reference="contracts/currencies">
-              <TextField source="name" />
-            </ReferenceField>
-            <TextField source="labourHours" />
-            <ReferenceField source="seniorityId" reference="seniorities">
-              <ChipField source="name" />
-            </ReferenceField>
-            {HasPermissions("assignments", "update") && <EditButton />}
-          </Datagrid>
-        </ReferenceManyField>
-      </Tab>
-      {/*<Tab label="Vacations and Licencies"></Tab>
+              </ReferenceField>
+              <NumberField source="hoursPerMonth" />
+              <NumberField source="vacations" />
+              <TextField source="benefits" />
+              <TextField source="notes" />
+              {HasPermissions("contracts", "update") && <EditButton />}
+            </Datagrid>
+          </ReferenceManyField>
+        </Tab>
+        <Tab label="Assigments">
+          <ReferenceManyField
+            label="Assignments"
+            reference="assignments"
+            target="employeeId"
+            sort={{ field: "startDate", order: "DESC" }}
+          >
+            {HasPermissions("assignments", "create") && (
+              <RedirectButton
+                form="create"
+                resource="assignments"
+                text="+ CREATE"
+                recordId={DisplayRecordCurrentId()}
+                source="employeeProfile"
+              />
+            )}
+            <Datagrid>
+              <ReferenceField source="projectId" reference="projects">
+                <TextField source="name" />
+              </ReferenceField>
+              <DateField source="startDate" locales={locale} />
+              <DateField source="endDate" locales={locale} />
+              <ReferenceField source="roleId" reference="roles">
+                <ChipField source="name" />
+              </ReferenceField>
+              <NumberField source="hoursPerMonth" />
+              <TextField source="billableRate" />
+              <ReferenceField
+                source="currency"
+                reference="contracts/currencies"
+              >
+                <TextField source="name" />
+              </ReferenceField>
+              <TextField source="labourHours" />
+              <ReferenceField source="seniorityId" reference="seniorities">
+                <ChipField source="name" />
+              </ReferenceField>
+              {HasPermissions("assignments", "update") && <EditButton />}
+            </Datagrid>
+          </ReferenceManyField>
+        </Tab>
+        {/*<Tab label="Vacations and Licencies"></Tab>
       <Tab label="Documents"></Tab>
       Hidden empty tabs until developed
       */}
-    </TabbedShowLayout>
-  </Show>
-)};
+      </TabbedShowLayout>
+    </Show>
+  );
+};


### PR DESCRIPTION
# Description :pencil:

Re order fields in Employee profile according to the criteria used in create employee from, in addition the styles where updated to hide the checkboxes in payment information data and also for all field keep the same height 

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-75

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
![image](https://user-images.githubusercontent.com/46864825/236214876-16c9564d-2a81-4768-90e3-9584ec12f0e4.png)
