### PR TITLE
EN-82: See available vacations days per employee

### DIFF
--- a/.github/workflows/deploy-dev-aws.yml
+++ b/.github/workflows/deploy-dev-aws.yml
@@ -3,7 +3,7 @@ name: Deploy to dev
 on:
   push:
     branches:
-      - main
+      - develop
 
 env:
   AWS_REGION: us-east-1

--- a/src/employeeProfiles.js
+++ b/src/employeeProfiles.js
@@ -20,8 +20,18 @@ import {
   useGetManyReference,
   useGetOne,
   useLocaleState,
+  useList,
+  ListContextProvider,
 } from "react-admin";
-import { Avatar, Box, Divider, Grid } from "@mui/material";
+import {
+  Avatar,
+  Box,
+  Chip,
+  Divider,
+  Grid,
+  Modal,
+  Typography,
+} from "@mui/material";
 import RedirectButton from "./components/RedirectButton";
 import { HasPermissions, ListActions } from "./components/layout/CustomActions";
 
@@ -57,6 +67,33 @@ const GetActiveContract = () => {
   return activeContract;
 };
 
+const GetVacationDetail = () => {
+  const employeeId = useGetRecordId();
+  const { data: vacations } = useGetManyReference("vacations", {
+    target: "employeeId",
+    id: employeeId,
+  });
+
+  vacations?.forEach((v) => (v.remainingDays = v.credit - v.debit));
+  return vacations;
+};
+
+const GetAvailableDays = () => {
+  let totalCredit = 0;
+  let totalDebit = 0;
+  let vacations = GetVacationDetail();
+  let availableDays = 0;
+
+  vacations?.forEach((v) => {
+    if (parseInt(v.year) <= new Date().getFullYear()) {
+      totalCredit += v.credit;
+      totalDebit += v.debit;
+    }
+  });
+  availableDays = totalCredit - totalDebit;
+  return availableDays;
+};
+
 const GetLatestAssignment = () => {
   const employeeId = useGetRecordId();
 
@@ -69,8 +106,8 @@ const GetLatestAssignment = () => {
   // It will be changed when the active field is added to assignments
 
   const latestAssignment = React.useMemo(() => {
-    if (Array.isArray(assignments)) {
-      return assignments.find((a) => a.id === employee.lastAssignmentId);
+    if (Array.isArray(assignments) && employee) {
+      return assignments.find((a) => a.id === employee?.lastAssignmentId);
     }
     return undefined;
   }, [assignments, employee]);
@@ -78,10 +115,33 @@ const GetLatestAssignment = () => {
   return latestAssignment;
 };
 
-const CustomEmpty = () => <div>No vacations found</div>;
+const CustomEmpty = ({ message }) => <div>{message}</div>;
+
+const style = {
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: 400,
+  bgcolor: "background.paper",
+  border: "2px solid #000",
+  boxShadow: 24,
+  p: 4,
+};
 
 export const EmployeeProfile = () => {
   const [locale] = useLocaleState();
+  const data = GetVacationDetail();
+  const listContext = useList({ data });
+  const availableDays = GetAvailableDays();
+  const [open, setOpen] = React.useState(false);
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
   return (
     <Show
       title="Show employee"
@@ -205,91 +265,41 @@ export const EmployeeProfile = () => {
           </ArrayField>
         </Tab>
         <Tab label="Contracts">
-        <ReferenceManyField
-          label=""
-          reference="contracts"
-          target="employeeId"
-          sort={{ field: "startDate", order: "DESC" }}
-        >
-          {HasPermissions("contracts", "create") && (
-            <RedirectButton
-              form="create"
-              resource="contracts"
-              text="+ CREATE"
-              recordId={DisplayRecordCurrentId()}
-              record={GetActiveContract()}
-              source="employeeProfile"
-            />
-          )}
-          <Datagrid rowStyle={activeValue}>
-            <ReferenceField
-              source="contractType"
-              reference="contracts/contract-types"
-            >
-              <ChipField source="value" />
-            </ReferenceField>
-            <FunctionField
-              label="Status"
-              sortBy="active"
-              sortByOrder="ASC"
-              render={(record) =>
-                record.active === true ? "Active" : "Inactive"
-              }
-            />
-            ;
-            <ReferenceField source="companyId" reference="companies">
-              <TextField source="name" />
-            </ReferenceField>
-            <DateField source="startDate" locales={locale}/>
-            <DateField source="endDate" locales={locale}/>
-            <ReferenceField source="roleId" reference="roles">
-              <ChipField source="name" />
-            </ReferenceField>
-            <ReferenceField source="seniorityId" reference="seniorities">
-              <ChipField source="name" />
-            </ReferenceField>
-            <NumberField source="hoursPerMonth" />
-            <NumberField source="vacations" />
-            <TextField source="benefits" />
-            <TextField source="notes" />
-            {HasPermissions("contracts", "update") && <EditButton />}
-          </Datagrid>
-        </ReferenceManyField>
-      </Tab>
-      <Tab label="Assigments">
-        <ReferenceManyField
-          label=""
-          reference="assignments"
-          target="employeeId"
-          sort={{ field: "startDate", order: "DESC" }}
-        >
-          {HasPermissions("assignments", "create") && (
-            <RedirectButton
-              form="create"
-              resource="assignments"
-              text="+ CREATE"
-              recordId={DisplayRecordCurrentId()}
-              record={GetLatestAssignment()}
-              source="employeeProfile"
-            />
-          )}
-          <Datagrid rowStyle={activeValue}>
-            <ReferenceField source="projectId" reference="projects">
-              <TextField source="name" />
-            </ReferenceField>
-            <FunctionField
-              label="Status"
-              sortBy="active"
-              sortByOrder="ASC"
-              render={(record) =>
-                record.active === true ? "Active" : "Inactive"
-              }
-            />
-            <ReferenceField source="projectId" reference="projects" label="Client">
-              <ReferenceField source="clientId" reference="clients">
+          <ReferenceManyField
+            label=""
+            reference="contracts"
+            target="employeeId"
+            sort={{ field: "startDate", order: "DESC" }}
+          >
+            {HasPermissions("contracts", "create") && (
+              <RedirectButton
+                form="create"
+                resource="contracts"
+                text="+ CREATE"
+                recordId={DisplayRecordCurrentId()}
+                record={GetActiveContract()}
+                source="employeeProfile"
+              />
+            )}
+            <Datagrid rowStyle={activeValue}>
+              <ReferenceField
+                source="contractType"
+                reference="contracts/contract-types"
+              >
+                <ChipField source="value" />
+              </ReferenceField>
+              <FunctionField
+                label="Status"
+                sortBy="active"
+                sortByOrder="ASC"
+                render={(record) =>
+                  record.active === true ? "Active" : "Inactive"
+                }
+              />
+              ;
+              <ReferenceField source="companyId" reference="companies">
                 <TextField source="name" />
               </ReferenceField>
-            </ReferenceField>
               <DateField source="startDate" locales={locale} />
               <DateField source="endDate" locales={locale} />
               <ReferenceField source="roleId" reference="roles">
@@ -305,40 +315,136 @@ export const EmployeeProfile = () => {
               {HasPermissions("contracts", "update") && <EditButton />}
             </Datagrid>
           </ReferenceManyField>
-        </Tab>        
-        {HasPermissions("vacations", "create") && (
-          <Tab label="Vacations and Licencies">
-            <ReferenceManyField
-              label=""
-              reference="vacations"
-              target="employeeId"
-              sort={{ field: "year", order: "ASC" }}
-            >
+        </Tab>
+        <Tab label="Assigments">
+          <ReferenceManyField
+            label=""
+            reference="assignments"
+            target="employeeId"
+            sort={{ field: "startDate", order: "DESC" }}
+          >
+            {HasPermissions("assignments", "create") && (
               <RedirectButton
                 form="create"
-                resource="vacations"
+                resource="assignments"
                 text="+ CREATE"
-                label=""
-                source="employeeProfile"
                 recordId={DisplayRecordCurrentId()}
+                record={GetLatestAssignment()}
+                source="employeeProfile"
               />
-              <Datagrid
-                bulkActionButtons={false}
-                empty={<CustomEmpty />}
-                sx={{
-                  "& .column-year": { width: "33.33%", textAlign: "left" },
-                  "& .column-credit": { width: "33.33%", textAlign: "center" },
-                  "& .column-undefined": {
-                    width: "33.33%",
-                    textAlign: "center",
-                  },
-                }}
+            )}
+            <Datagrid rowStyle={activeValue}>
+              <ReferenceField source="projectId" reference="projects">
+                <TextField source="name" />
+              </ReferenceField>
+              <FunctionField
+                label="Status"
+                sortBy="active"
+                sortByOrder="ASC"
+                render={(record) =>
+                  record.active === true ? "Active" : "Inactive"
+                }
+              />
+              <ReferenceField
+                source="projectId"
+                reference="projects"
+                label="Client"
               >
-                <TextField source="year" width={10} />
-                <NumberField source="credit" width={10} />
-                {HasPermissions("vacations", "update") && <EditButton />}
-              </Datagrid>
-            </ReferenceManyField>
+                <ReferenceField source="clientId" reference="clients">
+                  <TextField source="name" />
+                </ReferenceField>
+              </ReferenceField>
+              <DateField source="startDate" locales={locale} />
+              <DateField source="endDate" locales={locale} />
+              <ReferenceField source="roleId" reference="roles">
+                <ChipField source="name" />
+              </ReferenceField>
+              <ReferenceField source="seniorityId" reference="seniorities">
+                <ChipField source="name" />
+              </ReferenceField>
+              <NumberField source="hoursPerMonth" />
+              <NumberField source="vacations" />
+              <TextField source="benefits" />
+              <TextField source="notes" />
+              {HasPermissions("contracts", "update") && <EditButton />}
+            </Datagrid>
+          </ReferenceManyField>
+        </Tab>
+        {HasPermissions("vacations", "create") && (
+          <Tab label="Vacations">
+            <RedirectButton
+              form="create"
+              resource="vacations"
+              text="+ CREATE"
+              label=""
+              source="employeeProfile"
+              recordId={DisplayRecordCurrentId()}
+            />
+            <ListContextProvider value={listContext}>
+              <div style={{ display: "flex", justifyContent: "center" }}>
+                <Datagrid
+                  bulkActionButtons={false}
+                  empty={<CustomEmpty message="No vacations found" />}
+                  size="medium"
+                  sx={{
+                    width: "30%",
+
+                    "& .column-year": {
+                      width: "50%",
+                      textAlign: "left",
+                    },
+                    "& .column-remainingDays": {
+                      width: "50%",
+                      textAlign: "left",
+                    },
+                  }}
+                >
+                  <TextField source="year" label="Year" />
+                  <TextField
+                    source="remainingDays"
+                    label="Remaining vacation days"
+                  />
+                </Datagrid>
+              </div>
+            </ListContextProvider>
+            <Typography variant="h7" align="center">
+              <Chip
+                onClick={handleOpen}
+                label={"Available days: " + availableDays}
+              />
+              <Typography component="h3" align="center">
+                <Modal open={open} onClose={handleClose}>
+                  <Box sx={{ ...style, width: 400 }}>
+                    <ReferenceManyField
+                      reference="vacations"
+                      target="employeeId"
+                      sort={{ field: "year", order: "ASC" }}
+                    >
+                      {" "}
+                      <Typography
+                        id="modal-modal-title"
+                        variant="h6"
+                        component="h2"
+                        align="center"
+                      >
+                        Vacations details
+                      </Typography>
+                      <Datagrid
+                        bulkActionButtons={false}
+                        empty={<CustomEmpty message="No vacations found" />}
+                      >
+                        <TextField source="year" />
+                        <NumberField source="credit" />
+                        <NumberField source="debit" />
+                        {HasPermissions("vacations", "update") && (
+                          <EditButton />
+                        )}
+                      </Datagrid>
+                    </ReferenceManyField>
+                  </Box>
+                </Modal>
+              </Typography>
+            </Typography>
           </Tab>
         )}
         {/*<Tab label="Documents"></Tab>
@@ -348,5 +454,3 @@ export const EmployeeProfile = () => {
     </Show>
   );
 };
-
-

--- a/src/employees.js
+++ b/src/employees.js
@@ -11,6 +11,7 @@ import {
   useListContext,
   SearchInput,
   useLocaleState,
+  FilterButton,
 } from "react-admin";
 import {
   Card,
@@ -18,6 +19,7 @@ import {
   CardActions,
   Typography,
   CardActionArea,
+  Chip,
 } from "@mui/material";
 import {
   red,
@@ -40,6 +42,7 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import ListBuilder from "./components/forms/ListBuilder";
 import { exporter } from "./utils/exporter";
+import QuickFilter from "./components/filters/QuickFilter";
 
 const COLOR_BG = [
   red[500],
@@ -59,7 +62,7 @@ const formData = [
     title: "Personal Information",
     inputsList: [
       { name: "internalId", type: "string", required: true },
-      {}, // a blank space
+      {}, // a blank space,
       {
         name: "Employee",
         type: "multiSelect",
@@ -115,11 +118,18 @@ const formData = [
     ],
   },
   {
-    customSections: ["paymentInformationSection", "notesSection"],
+    customSections: [
+      "paymentInformationSection",
+      "notesSection",
+      "activeSection",
+    ],
   },
 ];
 
-const employeeFilters = [<SearchInput source="q" alwaysOn />];
+const employeeFilters = [
+  <SearchInput source="q" alwaysOn />,
+  <QuickFilter source="active" label="Active" defaultValue={true} />,
+];
 
 const fieldsList = [
   { name: "firstName", type: "text" },
@@ -131,6 +141,7 @@ const fieldsList = [
   { name: "client", type: "text" },
   { name: "project", type: "text" },
   { name: "role", type: "text" },
+  { name: "availableDays", type: "text" },
 ];
 
 export const EmployeeList = () => {
@@ -157,32 +168,30 @@ export const EmployeeList = () => {
     <List
       sort={{ field: "internalId", order: "ASC" }}
       component="div"
-      actions={false}
+      actions={<FilterButton />}
       filters={employeeFilters}
       exporter={exporter(fieldsList, "employees")}
     >
-      <>
-        <TopToolbar
-          sx={{
-            minHeight: { sm: 56 },
-            justifyContent: "space-between",
-          }}
-        >
-          <Box>
-            <RowRadioButtonGroup
-              title={"View mode"}
-              value={viewOptionValue}
-              handleChange={handleChange}
-              options={viewOptions}
-            />
-          </Box>
-          <Box>
-            {HasPermissions("employees", "create") && <CreateButton />}
-            <ExportButton />
-          </Box>
-        </TopToolbar>
-        <EmployeeInformation renderAs={viewOptionValue} />
-      </>
+      <TopToolbar
+        sx={{
+          minHeight: { sm: 56 },
+          justifyContent: "space-between",
+        }}
+      >
+        <Box>
+          <RowRadioButtonGroup
+            title={"View mode"}
+            value={viewOptionValue}
+            handleChange={handleChange}
+            options={viewOptions}
+          />
+        </Box>
+        <Box>
+          {HasPermissions("employees", "create") && <CreateButton />}
+          <ExportButton />
+        </Box>
+      </TopToolbar>
+      <EmployeeInformation renderAs={viewOptionValue} />
     </List>
   );
 };
@@ -252,13 +261,22 @@ const EmployeeInformation = ({ renderAs = "list" }) => {
                       <Typography noWrap align="center">
                         {record.role}
                       </Typography>
+                      {HasPermissions("employees", "create") && 
+                      <Typography variant="h7" component="h3" align="center">
+                        <Chip
+                          label={"Available days: " + record.availableDays}
+                        />
+                      </Typography>
+                      }
                     </Box>
                   </CardContent>
                 </CardActionArea>
+                <div style={{ display: "flex", justifyContent: "center" }}>
                 <CardActions>
                   <ShowButton />
                   {HasPermissions("employees", "update") && <EditButton />}
                 </CardActions>
+                </div>
               </Card>
             </Grid>
           </RecordContextProvider>


### PR DESCRIPTION
# Description :pencil:

Now we can see the available vacations days per employee in employee cards and profile. 

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-82

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

Employee cards
![image](https://github.com/entropy-code/entropay-admin-ui/assets/70980835/c0a65e7c-6383-4c0b-bd4f-e4405c020dd6)

Employee list
![image](https://github.com/entropy-code/entropay-admin-ui/assets/70980835/53827725-465c-4e7b-886e-39129b48c2f6)

Employee profile
![image](https://github.com/entropy-code/entropay-admin-ui/assets/70980835/e7eae700-eac6-464d-9908-fdebd1aeba6c)

