### PR TITLE
EN-96: personal info updates

### DIFF
--- a/src/employeeProfiles.js
+++ b/src/employeeProfiles.js
@@ -82,7 +82,7 @@ const GetVacationsAndAvailableDays = () => {
       v.remainingDays = v.credit - v.debit;
     });
   }
-  
+
   return {
     vacationDetailData,
     vacationAvailableDays,
@@ -126,7 +126,8 @@ const style = {
 
 export const EmployeeProfile = () => {
   const [locale] = useLocaleState();
-  const { vacationDetailData, vacationAvailableDays } = GetVacationsAndAvailableDays();
+  const { vacationDetailData, vacationAvailableDays } =
+    GetVacationsAndAvailableDays();
   const vacationDetailList = useList({ data: vacationDetailData });
   const [open, setOpen] = React.useState(false);
   const handleOpen = () => {
@@ -136,6 +137,7 @@ export const EmployeeProfile = () => {
   const handleClose = () => {
     setOpen(false);
   };
+
   return (
     <Show
       title="Show employee"
@@ -167,15 +169,37 @@ export const EmployeeProfile = () => {
             <TextField label="" source="personalEmail" />
           </SimpleShowLayout>
         </Grid>
-        {/*
-      <Grid item>
-        <SimpleShowLayout divider={<Divider flexItem />}>
-          <TextField label="Current assigment" source="" />
-          <DateField label="Hired Date" source="" />
-        </SimpleShowLayout>
-      </Grid>
-      Hidden empty fields until developed
-      */}
+        <Grid item>
+          <FunctionField
+            label=""
+            render={(record) => (
+              <SimpleShowLayout divider={<Divider flexItem />}>
+                {!record.startDate && (
+                  <span>This employee does not have any contracts</span>
+                )}
+                {record.startDate && (
+                  <TextField
+                    label="Start Date"
+                    source="startDate"
+                    record={record}
+                  />
+                )}
+                {record.startDate && !record.endDate && (
+                  <span>
+                    This employee does not have an end date for the contract
+                  </span>
+                )}
+                {record.endDate && (
+                  <TextField
+                    label="End Date"
+                    source="endDate"
+                    record={record}
+                  />
+                )}
+              </SimpleShowLayout>
+            )}
+          />
+        </Grid>
       </Grid>
       <TabbedShowLayout>
         <Tab label="Personal and financial information">

--- a/src/employeeProfiles.js
+++ b/src/employeeProfiles.js
@@ -124,6 +124,12 @@ const style = {
   p: 4,
 };
 
+const styleForSpan = {
+  display: "inline-flex",
+  alignItems: "center",
+  margin: "0 50%",
+};
+
 export const EmployeeProfile = () => {
   const [locale] = useLocaleState();
   const { vacationDetailData, vacationAvailableDays } =
@@ -175,26 +181,40 @@ export const EmployeeProfile = () => {
             render={(record) => (
               <SimpleShowLayout divider={<Divider flexItem />}>
                 {!record.startDate && (
-                  <span>This employee does not have any contracts</span>
+                  <>
+                    <Typography variant="subtitle2" color="textSecondary">
+                      Start Date
+                    </Typography>
+                    <span style={styleForSpan}> - </span>
+                    <Typography variant="subtitle2" color="textSecondary">
+                      End Date
+                    </Typography>
+                    <span style={styleForSpan}>-</span>
+                  </>
                 )}
                 {record.startDate && (
-                  <TextField
-                    label="Start Date"
-                    source="startDate"
-                    record={record}
-                  />
+                  <>
+                    <Typography variant="subtitle2" color="textSecondary">
+                      Start Date
+                    </Typography>
+                    <DateField label="" source="startDate" record={record} />
+                  </>
                 )}
                 {record.startDate && !record.endDate && (
-                  <span>
-                    This employee does not have an end date for the contract
-                  </span>
+                  <>
+                    <Typography variant="subtitle2" color="textSecondary">
+                      End Date
+                    </Typography>
+                    <span style={styleForSpan}> - </span>
+                  </>
                 )}
                 {record.endDate && (
-                  <TextField
-                    label="End Date"
-                    source="endDate"
-                    record={record}
-                  />
+                  <>
+                    <Typography variant="subtitle2" color="textSecondary">
+                      End Date
+                    </Typography>
+                    <DateField label="" source="endDate" record={record} />
+                  </>
                 )}
               </SimpleShowLayout>
             )}


### PR DESCRIPTION
# Description :pencil:

Now the front-end can receive endDate and startDate. It displays a corresponding message for the 3 cases: if only startDate is present, it shows the date and a message indicating that there are no contracts with an end date. If there is no startDate, it displays a message stating that there are no contracts. And if both dates are available, it shows both of them.

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-96

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:


If no contracts are available, it displays the following message
![image](https://github.com/entropy-code/entropay-admin-ui/assets/96883646/e081939c-2bf4-4c50-96dd-27031754cd07)

If there is a contract without an end date, it displays the following message:
![image](https://github.com/entropy-code/entropay-admin-ui/assets/96883646/fd436bdc-9a79-4828-9a81-096976594f04)

If the contract has both start and end dates, it displays the following message:
![image](https://github.com/entropy-code/entropay-admin-ui/assets/96883646/292c7454-ad33-435b-b4b9-a8464a0175da)



