### PR TITLE
EN-81: See next time off of my employees

### DIFF
--- a/src/employees.js
+++ b/src/employees.js
@@ -142,7 +142,7 @@ const fieldsList = [
   { name: "project", type: "text" },
   { name: "role", type: "text" },
   { name: "availableDays", type: "text" },
-  { name: "nearestPto", type: "text" },
+  { name: "nearestPto", type: "date" },
 ];
 
 export const EmployeeList = () => {
@@ -215,7 +215,7 @@ const EmployeeInformation = ({ renderAs = "list" }) => {
                 <CardActionArea
                   component={Link}
                   to={`${record.id}/show`}
-                  sx={{ minHeight: "384px" }}
+                  sx={{ minHeight: "380px" }}
                   style={{ textDecoration: "none" }}
                 >
                   <CardContent sx={{ padding: 1 }}>
@@ -268,10 +268,19 @@ const EmployeeInformation = ({ renderAs = "list" }) => {
                           label={"Available days: " + record.availableDays}
                         />
                       </Typography>
-                      <Typography variant="h7" component="h3" align="center">
+                      <Typography variant="h7" component="h6" align="center">
                         {record.nearestPto && (
                           <Chip
-                            label={"Next time off on: " + record.nearestPto}
+                            label={
+                              <>
+                                Next time off:{" "}
+                                <DateField
+                                  source="nearestPto"
+                                  locales={locale}
+                                />
+                              </>
+                            }
+                            variant="filled"
                             color="success"
                           />
                         )}

--- a/src/employees.js
+++ b/src/employees.js
@@ -142,6 +142,7 @@ const fieldsList = [
   { name: "project", type: "text" },
   { name: "role", type: "text" },
   { name: "availableDays", type: "text" },
+  { name: "nearestPto", type: "text" },
 ];
 
 export const EmployeeList = () => {
@@ -214,6 +215,7 @@ const EmployeeInformation = ({ renderAs = "list" }) => {
                 <CardActionArea
                   component={Link}
                   to={`${record.id}/show`}
+                  sx={{ minHeight: "384px" }}
                   style={{ textDecoration: "none" }}
                 >
                   <CardContent sx={{ padding: 1 }}>
@@ -265,6 +267,14 @@ const EmployeeInformation = ({ renderAs = "list" }) => {
                         <Chip
                           label={"Available days: " + record.availableDays}
                         />
+                      </Typography>
+                      <Typography variant="h7" component="h3" align="center">
+                        {record.nearestPto && (
+                          <Chip
+                            label={"Next time off on: " + record.nearestPto}
+                            color="success"
+                          />
+                        )}
                       </Typography>
                     </Box>
                   </CardContent>


### PR DESCRIPTION
# Description :pencil:
Now we can easily see the next time off for employees, it was added to the cards.

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-81

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

Employee cards
![image](https://github.com/entropy-code/entropay-admin-ui/assets/70980835/1775bf14-e7fe-4574-9b0d-fb0ac59b48d9)

Employee list
![image](https://github.com/entropy-code/entropay-admin-ui/assets/70980835/b7e1cc17-028e-42b1-a299-e06afd7f33e1)