### PR TITLE
EN-101: Displayed client email in employee card/list and change avail…

### DIFF
--- a/src/components/forms/ListBuilder.jsx
+++ b/src/components/forms/ListBuilder.jsx
@@ -18,15 +18,15 @@ const ListBuilder = ({ fieldsList, locale, hasShowButton, resource }) => {
           switch (field.type) {
             case "text":
               return (
-                <TextField key={index} source={field.name} />
+                <TextField key={index} source={field.name} label={field?.label}/>
               );
             case "date":
               return (
-                <DateField key={index} source={field.name} locale={locale} />
+                <DateField key={index} source={field.name} locale={locale} label={field?.label}/>
               );
             case "number":
               return (
-                <NumberField key={index} source={field.name} />
+                <NumberField key={index} source={field.name} label={field?.label}/>
               );
             case "reference":
               return (

--- a/src/employees.js
+++ b/src/employees.js
@@ -134,14 +134,14 @@ const employeeFilters = [
 const fieldsList = [
   { name: "firstName", type: "text" },
   { name: "lastName", type: "text" },
-  { name: "personalEmail", type: "text" },
+  { name: "labourEmail", type: "text" },
   { name: "startDate", type: "date" },
   { name: "city", type: "text" },
   { name: "country", type: "text" },
   { name: "client", type: "text" },
   { name: "project", type: "text" },
   { name: "role", type: "text" },
-  { name: "availableDays", type: "text" },
+  { name: "availableDays", type: "number", label: "Holidays" },
   { name: "nearestPto", type: "date" },
 ];
 
@@ -249,7 +249,7 @@ const EmployeeInformation = ({ renderAs = "list" }) => {
                         {record.firstName} {record.lastName}
                       </Typography>
                       <Typography noWrap align="center">
-                        {record.personalEmail}
+                        {record.labourEmail ? record.labourEmail : "-"}
                       </Typography>
                       <Typography noWrap align="center">
                         <DateField source="startDate" locales={locale} />
@@ -264,9 +264,7 @@ const EmployeeInformation = ({ renderAs = "list" }) => {
                         {record.role}
                       </Typography>
                       <Typography variant="h7" component="h3" align="center">
-                        <Chip
-                          label={"Available days: " + record.availableDays}
-                        />
+                        <Chip label={"Holidays: " + record.availableDays} />
                       </Typography>
                       <Typography variant="h7" component="h6" align="center">
                         {record.nearestPto && (


### PR DESCRIPTION
# Description :pencil:

The staff email was changed to the labor email in both the list and card views. Additionally, the name 'Available Days' was also changed to 'Holidays' to make it more intuitive.

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-101

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

![image](https://github.com/entropy-code/entropay-admin-ui/assets/96883646/ea95479a-3a56-44b0-9b14-912f6e399149)
![image](https://github.com/entropy-code/entropay-admin-ui/assets/96883646/09089535-9d26-4e8f-8557-5ea2d708064a)


