### PR TITLE
EN-118: Changed label when creating a half day pto

### DIFF
--- a/src/ptos.tsx
+++ b/src/ptos.tsx
@@ -48,9 +48,8 @@ const formData = [
       {},
       { name: "ptoStartDate", type: "date", required: true },
       { name: "ptoEndDate", type: "date", required: true },
-      { name: "setHours", type: "boolean"}, 
+      { name: "isHalfDay", type: "boolean", label: "take half day off" },
       {},
-      { name: "labourHours", type: "conditionNumberField", conditionField: "setHours"}
     ]
   },
   {
@@ -82,7 +81,6 @@ export const PtoList = () => {
       <TextField source="status"/>
       <TextField source="details"/>
       <NumberField source="days"/>
-      <NumberField source="labourHours"/>
       <EditButton />
       <DeleteButton />
     </Datagrid>

--- a/src/ptos.tsx
+++ b/src/ptos.tsx
@@ -48,7 +48,7 @@ const formData = [
       {},
       { name: "ptoStartDate", type: "date", required: true },
       { name: "ptoEndDate", type: "date", required: true },
-      { name: "isHalfDay", type: "boolean", label: "take half day off" },
+      { name: "isHalfDay", type: "boolean", label: "Half day off" },
       {},
     ]
   },


### PR DESCRIPTION
# Description :pencil:

Changed label from "take half day off" to "half day off" when creating a half day pto

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-118

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:

![image](https://github.com/entropy-code/entropay-admin-ui/assets/89614950/a198a354-be32-4d95-bc9e-766ed5189670)

