### PR TITLE
EN-134: Improve navigation and other minor improvements

### DIFF
--- a/src/assignments.tsx
+++ b/src/assignments.tsx
@@ -128,7 +128,7 @@ export const AssignmentList = () => {
       filters={assignmentFilters}
     >
       <Datagrid rowClick={"edit"}>
-        <ReferenceField source="employeeId" reference="employees">
+        <ReferenceField source="employeeId" reference="employees" link="show">
           <WrapperField label="Full Name">
             <TextField source="lastName" /> <TextField source="firstName" />
           </WrapperField>
@@ -139,26 +139,26 @@ export const AssignmentList = () => {
             record.active === true ? "Active" : "Inactive"
           }
         />
-        <ReferenceField source="projectId" reference="projects">
+        <ReferenceField source="projectId" reference="projects" link="show">
           <TextField source="name" />
         </ReferenceField>
-        <ReferenceField source="projectId" reference="projects" label="Client">
-          <ReferenceField source="clientId" reference="clients">
+        <ReferenceField source="projectId" reference="projects" label="Client" link={false}>
+          <ReferenceField source="clientId" reference="clients" link={false}>
             <TextField source="name" />
           </ReferenceField>
         </ReferenceField>
         <DateField source="startDate" locales={locale} />
         <DateField source="endDate" locales={locale} />
-        <ReferenceField source="roleId" reference="roles">
+        <ReferenceField source="roleId" reference="roles" link={false}>
           <TextField source="name" />
         </ReferenceField>
         <NumberField source="hoursPerMonth" />
         <TextField source="billableRate" />
-        <ReferenceField source="currency" reference="contracts/currencies">
+        <ReferenceField source="currency" reference="contracts/currencies" link={false}>
           <TextField source="name" />
         </ReferenceField>
         <TextField source="labourHours" />
-        <ReferenceField source="seniorityId" reference="seniorities">
+        <ReferenceField source="seniorityId" reference="seniorities" link={false}>
           <TextField source="name" />
         </ReferenceField>
         <ShowButton />

--- a/src/clients.js
+++ b/src/clients.js
@@ -10,7 +10,7 @@ import {
 } from "react-admin";
 import CreateForm from "./components/forms/CreateForm";
 import EditForm from "./components/forms/EditForm";
-import { ListActions, HasPermissions } from "./components/layout/CustomActions";
+import { HasPermissions } from "./components/layout/CustomActions";
 
 const formData = [
   {
@@ -56,10 +56,10 @@ const formData = [
 export const ClientList = () => {
   const [locale] = useLocaleState();
   return (
-    <List actions={<ListActions entity={"clients"} />}>
+    <List>
       <Datagrid>
         <TextField source="name" />
-        <ReferenceField source="companyId" reference="companies">
+        <ReferenceField source="companyId" reference="companies" link={false}>
           <TextField source="name" />
         </ReferenceField>
         <TextField source="address" />
@@ -73,7 +73,7 @@ export const ClientList = () => {
         <DateField source="modifiedAt" locales={locale} />
         <DateField source="createdAt" locales={locale} />
         {HasPermissions("clients", "update") && (
-          <EditButton variant="outlined" />
+          <EditButton/>
         )}
       </Datagrid>
     </List>

--- a/src/components/forms/EditForm.jsx
+++ b/src/components/forms/EditForm.jsx
@@ -28,6 +28,9 @@ const GetRedirectPath = (resource, data) => {
     case "vacations":
       redirectPath = `/employees/${data.employeeId}/show/3`;
       break;
+    case "ptos":
+      redirectPath = `/employees/${data.employeeId}/show/4`;
+      break;
     default:
       redirectPath = `/${resource}`;
       break;

--- a/src/components/forms/FormViewSections.tsx
+++ b/src/components/forms/FormViewSections.tsx
@@ -80,7 +80,7 @@ const FormViewSections = (config: any) => {
                     <ReferenceField 
                       source={listItem.referenceValues.source} 
                       reference={listItem.referenceValues.reference} 
-                      />
+                      link="show"/>
                   </Labeled>
                   ) : undefined}
 
@@ -89,6 +89,7 @@ const FormViewSections = (config: any) => {
                     <ReferenceField 
                       source={listItem.referenceValues.source} 
                       reference={listItem.referenceValues.reference} 
+                      link="show"
                       >
                         <TextField source={listItem.referenceValues.optionText}></TextField>
                     </ReferenceField> 

--- a/src/components/forms/ViewForm.jsx
+++ b/src/components/forms/ViewForm.jsx
@@ -5,6 +5,7 @@ import {
 } from "react-admin";
 import Header from "../Header";
 import FormViewSections from "./FormViewSections";
+import { EntityViewActions } from "../layout/CustomActions";
 
 const ViewForm = ({ formData, title, resource }) => {
   return (
@@ -12,7 +13,7 @@ const ViewForm = ({ formData, title, resource }) => {
       <Box display="flex" justifyContent="space-between" alignItems="center">
         <Header title={title} subtitle="View" />
       </Box>
-      <Show>
+      <Show actions={<EntityViewActions entity={resource} /> }>
         <SimpleShowLayout>
           <Box width="100%">
             {formData &&

--- a/src/components/layout/CustomActions.js
+++ b/src/components/layout/CustomActions.js
@@ -1,20 +1,26 @@
 import { 
-    useListContext,
     TopToolbar,
     CreateButton,
-    ExportButton,
+    ListButton,
 } from 'react-admin';
 
-export const ListActions = ({entity}) => {
-    const { total, isLoading } = useListContext();
-    return (
-        <TopToolbar>
-            {HasPermissions(entity, "create") && <CreateButton/>}
-            <ExportButton disabled={isLoading || total === 0} />
-        </TopToolbar>
-    );
-};
+import ArowBackIcon from '@rsuite/icons/ArowBack';
 
+const icons = {
+    backIcon: <ArowBackIcon />,
+  };
+
+export const EntityViewActions = ({ entity }) => {
+    return (
+      <TopToolbar sx={{ justifyContent: "space-between" }}>
+        <div style={{ display: "flex" }}>
+          <ListButton label='back' icon={icons.backIcon}/>
+        </div>
+        {HasPermissions(entity, "create") && <CreateButton />}
+      </TopToolbar>
+    );
+  };  
+  
 export const HasPermissions = (entity, action) => {
     const config = JSON.parse(localStorage.getItem('config')) || {}
     const permissions = config.permissions || []
@@ -29,4 +35,4 @@ export const HasPermissions = (entity, action) => {
     
 };
 
-export default ListActions
+export default EntityViewActions

--- a/src/contracts.tsx
+++ b/src/contracts.tsx
@@ -123,16 +123,13 @@ export const ContractList = () => {
       filterDefaultValues={{ active: true }}
     >
       <Datagrid rowClick="edit">
-        <ReferenceField source="companyId" reference="companies">
+        <ReferenceField source="companyId" reference="companies" link={false}>
           <TextField source="name" />
         </ReferenceField>
-        <ReferenceField
-          source="contractType"
-          reference="contracts/contract-types"
-        >
+        <ReferenceField source="contractType" reference="contracts/contract-types" link={false}>
           <TextField source="value" />
         </ReferenceField>
-        <ReferenceField source="employeeId" reference="employees">
+        <ReferenceField source="employeeId" reference="employees" link="show">
           <WrapperField label="Full Name">
             <TextField source="lastName" /> <TextField source="firstName" />
           </WrapperField>
@@ -161,10 +158,10 @@ export const ContractList = () => {
         </ArrayField>
         <DateField source="startDate" locales={locale} />
         <DateField source="endDate" locales={locale} />
-        <ReferenceField source="roleId" reference="roles">
+        <ReferenceField source="roleId" reference="roles" link={false}>
           <TextField source="name" />
         </ReferenceField>
-        <ReferenceField source="seniorityId" reference="seniorities">
+        <ReferenceField source="seniorityId" reference="seniorities" link={false}>
           <TextField source="name" />
         </ReferenceField>
         <NumberField source="hoursPerMonth" />

--- a/src/employeeProfiles.js
+++ b/src/employeeProfiles.js
@@ -24,7 +24,7 @@ import {
   useLocaleState,
   WrapperField,
   useList,
-  ListContextProvider,
+  ListContextProvider
 } from "react-admin";
 import {
   Avatar,
@@ -36,7 +36,7 @@ import {
   Typography,
 } from "@mui/material";
 import RedirectButton from "./components/RedirectButton";
-import { HasPermissions, ListActions } from "./components/layout/CustomActions";
+import { HasPermissions, EntityViewActions } from "./components/layout/CustomActions";
 
 const COLOR_green = "#efe";
 const COLOR_white = "#white";
@@ -175,7 +175,7 @@ export const EmployeeProfile = () => {
   return (
     <Show
       title="Show employee"
-      actions={<ListActions entity={"employees"} />}
+      actions={<EntityViewActions entity={"employees"} /> }
       emptyWhileLoading
     >
       <Grid
@@ -374,6 +374,7 @@ export const EmployeeProfile = () => {
               <ReferenceField
                 source="contractType"
                 reference="contracts/contract-types"
+                link={false}
               >
                 <ChipField source="value" />
               </ReferenceField>
@@ -386,15 +387,15 @@ export const EmployeeProfile = () => {
                 }
               />
               ;
-              <ReferenceField source="companyId" reference="companies">
+              <ReferenceField source="companyId" reference="companies" link={false}>
                 <TextField source="name" />
               </ReferenceField>
               <DateField source="startDate" locales={locale} />
               <DateField source="endDate" locales={locale} />
-              <ReferenceField source="roleId" reference="roles">
+              <ReferenceField source="roleId" reference="roles" link={false}>
                 <ChipField source="name" />
               </ReferenceField>
-              <ReferenceField source="seniorityId" reference="seniorities">
+              <ReferenceField source="seniorityId" reference="seniorities" link={false}>
                 <ChipField source="name" />
               </ReferenceField>
               <NumberField source="hoursPerMonth" />
@@ -426,7 +427,7 @@ export const EmployeeProfile = () => {
               rowStyle={activeValue}
               empty={<CustomEmpty message="No assignments found" />}
             >
-              <ReferenceField source="projectId" reference="projects">
+              <ReferenceField source="projectId" reference="projects" link={false}>
                 <TextField source="name" />
               </ReferenceField>
               <FunctionField
@@ -441,17 +442,18 @@ export const EmployeeProfile = () => {
                 source="projectId"
                 reference="projects"
                 label="Client"
+                link={false}
               >
-                <ReferenceField source="clientId" reference="clients">
+                <ReferenceField source="clientId" reference="clients" link={false}>
                   <TextField source="name" />
                 </ReferenceField>
               </ReferenceField>
               <DateField source="startDate" locales={locale} />
               <DateField source="endDate" locales={locale} />
-              <ReferenceField source="roleId" reference="roles">
+              <ReferenceField source="roleId" reference="roles" link={false}>
                 <ChipField source="name" />
               </ReferenceField>
-              <ReferenceField source="seniorityId" reference="seniorities">
+              <ReferenceField source="seniorityId" reference="seniorities" link={false}>
                 <ChipField source="name" />
               </ReferenceField>
               <NumberField source="hoursPerMonth" />
@@ -560,7 +562,7 @@ export const EmployeeProfile = () => {
                 bulkActionButtons={false}
                 empty={<CustomEmpty message="No ptos found" />}
               >
-                <ReferenceField source="leaveTypeId" reference="leave-types">
+                <ReferenceField source="leaveTypeId" reference="leave-types" link={false}>
                   <WrapperField label="Leave Type">
                     <TextField source="name" />
                   </WrapperField>

--- a/src/employees.js
+++ b/src/employees.js
@@ -11,7 +11,7 @@ import {
   useListContext,
   SearchInput,
   useLocaleState,
-  FilterButton,
+  FilterButton
 } from "react-admin";
 import {
   Card,

--- a/src/ptos.tsx
+++ b/src/ptos.tsx
@@ -9,7 +9,7 @@ import {
   ReferenceField,
   TextField,
   useLocaleState,
-  WrapperField
+  WrapperField,
 } from "react-admin";
 import CreateForm from "./components/forms/CreateForm";
 import EditForm from "./components/forms/EditForm";
@@ -66,12 +66,12 @@ export const PtoList = () => {
   return (
   <List>
     <Datagrid rowClick="edit">
-      <ReferenceField source="employeeId" reference="employees">
+      <ReferenceField source="employeeId" reference="employees" link="show">
         <WrapperField label="Full Name">
           <TextField source="firstName" /> <TextField source="lastName" />
         </WrapperField>
       </ReferenceField>
-      <ReferenceField source="leaveTypeId" reference="leave-types">
+      <ReferenceField source="leaveTypeId" reference="leave-types" link={false}>
         <WrapperField label="Leave Type">
           <TextField source="name" />
         </WrapperField>


### PR DESCRIPTION
# Description :pencil:
Added a button to back out of an employees profile into the employees list.
Added a button to back out of every entity that has a "/show" page into the list of that entity. eg: assignments, contracts
Now when clicking on an employee in the contracts list, the user will be redirected to the "/show" page for that employee insted of the "/edit" one, and it works the same for every entity that has a "/show" page defined, if there's no such page defined the text won't be hyperlinked meaning it wont redirect anywhere.

## Link to ticket :link:

https://entropyteam.atlassian.net/browse/EN-134

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? :microscope:
![image](https://github.com/entropy-code/entropay-admin-ui/assets/89614950/e4d81b14-8b10-4326-90ce-ef2b4226667d)

![image](https://github.com/entropy-code/entropay-admin-ui/assets/89614950/2cb34061-a67d-43b2-b855-b44dbf328420)

