### PR TITLE
Set the default value of the Boolean field to false

### DIFF
--- a/src/components/forms/FormSections.jsx
+++ b/src/components/forms/FormSections.jsx
@@ -101,7 +101,7 @@ const FormSection = ({ formSectionTitle, inputsList, customSections }) => {
                   <BooleanInput 
                     source={listItem.name}
                     label={listItem.label}
-                    defaultValue={true}
+                    defaultValue={listItem.defaultValue ?? true}
                   />
                 ) : undefined}
                 {listItem.type === "conditionNumberField" ? (

--- a/src/ptos.tsx
+++ b/src/ptos.tsx
@@ -55,7 +55,7 @@ const formData = [
       {},
       { name: "ptoStartDate", type: "date", required: true },
       { name: "ptoEndDate", type: "date", required: true },
-      { name: "isHalfDay", type: "boolean", label: "Half day off" },
+      { name: "isHalfDay", type: "boolean", label: "Half day off", defaultValue: false },
       {},
     ],
   },


### PR DESCRIPTION
Change to make the field "Half day off" false by default:

![image](https://github.com/entropy-code/entropay-admin-ui/assets/4777001/c96acedf-b4a1-49af-85fe-ff963c2f3bf8)
