### PR TITLE
Use custom query client to avoid refetching on windows focus

### DIFF
--- a/environments/default.env
+++ b/environments/default.env
@@ -1,0 +1,8 @@
+# App env
+REACT_APP_ENV=local
+# App home
+REACT_APP_HOME=http://localhost:3000
+# Api Employees
+REACT_APP_EMPLOYEES_URL=https://f4105dh98j.execute-api.us-east-1.amazonaws.com
+# Api User Auth
+REACT_APP_USER_AUTH_URL=https://06w1t29ee0.execute-api.us-east-1.amazonaws.com

--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import authProvider from "./authProvider";
 import { CustomLayout } from "./components/layout/CustomLayout";
 import { resourceMap } from "./resources";
 import { HasPermissions } from "./components/layout/CustomActions";
+import { QueryClient } from "react-query";
 
 console.log(config.env);
 
@@ -50,6 +51,15 @@ const dataProvider = simpleRestProvider(
   "X-Total-Count"
 );
 
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
 const App = () => {
   useCustomLocale();
   return (
@@ -58,6 +68,7 @@ const App = () => {
       layout={CustomLayout}
       dataProvider={dataProvider}
       authProvider={authProvider}
+      queryClient={queryClient}
     >
       {fetchResources}
     </Admin>


### PR DESCRIPTION
# Description :pencil:

We found that all queries were fetching every time the window regained focus, which is unnecessary for now; we can avoid this by passing a queryClient.

## Link to ticket :link:

https://3.basecamp.com/5776473/buckets/37034902/card_tables/cards/7627394904

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested? :microscope:

This was tested locally by using different queries and mutations.
