### PR TITLE
Fix for payment settlement bug after create a new contract

### DIFF
--- a/src/employeeProfiles.js
+++ b/src/employeeProfiles.js
@@ -64,11 +64,23 @@ const GetActiveContract = () => {
     },
   });
 
-  const activeContract = React.useMemo(() => {
-    if (Array.isArray(data)) {
-      return data[0];
+const activeContract = React.useMemo(() => {
+    if (!Array.isArray(data) || data.length === 0) {
+      return undefined;
     }
-    return undefined;
+
+    const contract = data[0];
+
+    return {
+      companyId: contract.companyId,
+      contractType: contract.contractType,
+      startDate: contract.startDate,
+      roleId: contract.roleId,
+      seniorityId: contract.seniorityId,
+      hoursPerMonth: contract.hoursPerMonth,
+      benefits: contract.benefits,
+
+    };
   }, [data]);
 
   return activeContract;


### PR DESCRIPTION
In this PR we fixed the bug with the payment settlement of the last active contract that disappeared after we create a new contract.
This bug was occasioned cause the logic that we used in the front-end. Before, when we create a new contract, we took all the information of the current active contract, included the payment settlement information.
Payment settlement it's an entity on his own, so when we took the information of the payment settlement of the current active contract, we were editing the payment settlement of that active contract and  referenced it to the new contract that we were creating. That ocassionated the problem that, after we saved the new contract, the payment settlement information of the last active contract, dissapeared.
In this new implementation we changed the logic of how we manage the take of the information of the current active contract and now, we still take all the information of the current active contract like the company, contract type, start date, job position information, etc. but now we don't took the payment settlement information that it's what's changes generally when we want to create a new contract for an employee that have an active contract at the time. Now we have to set the payment settlement information manually, like when we create a contract for an employee for first time, avoiding the problem and now the payment settlement information don't disappears anymore.
This is the solution that we agreed with Esteban and Maxi, at least for now.
Tested on my local branch and it's working fine.