### PR TITLE
Set default date range to previous month in billing report

### DIFF
--- a/src/billingReport.tsx
+++ b/src/billingReport.tsx
@@ -46,6 +46,10 @@ const filterStyles = {
 
 const parseISODate = (val?: string | null) => val && new Date(val).toISOString().slice(0, 10);
 
+// Calculate the first day of the previous month and the last day of the previous month
+const defaultStartDate = moment().subtract(1, "month").startOf("month").format("YYYY-MM-DD");
+const defaultEndDate = moment().subtract(1, "month").endOf("month").format("YYYY-MM-DD");
+
 const reportFilters = [
   <DateInput source="startDate"
              alwaysOn
@@ -70,11 +74,14 @@ export const BillingReportList = () => {
       exporter={exporter("billingReport", headers, headersRename)}
       actions={
         <>
-          <FilterButton />
           <ExportButton />
         </>
       }
       filters={reportFilters}
+      filterDefaultValues={{
+        startDate: defaultStartDate,
+        endDate: defaultEndDate
+      }}
       disableSyncWithLocation
     >
       <Datagrid bulkActionButtons={false}>


### PR DESCRIPTION
This pull request includes changes to the `src/billingReport.tsx` file to enhance the default date filtering for the billing report. The most important changes include adding default start and end dates for the previous month and updating the billing report list component to use these default dates.

Enhancements to default date filtering:

* [`src/billingReport.tsx`](diffhunk://#diff-002612cfcbcc51a94def2918bf354c16eee0cede3096b3caded8c88372b57775R49-R52): Added `defaultStartDate` and `defaultEndDate` constants to calculate the first and last days of the previous month using the `moment` library.
* [`src/billingReport.tsx`](diffhunk://#diff-002612cfcbcc51a94def2918bf354c16eee0cede3096b3caded8c88372b57775L73-R84): Updated the `BillingReportList` component to use the new default date values for `startDate` and `endDate` in the `filterDefaultValues` property.
