### PR TITLE
Add "Paid PTO" and "Notes" fields to projects and billing

### DIFF
--- a/src/billingReport.tsx
+++ b/src/billingReport.tsx
@@ -24,6 +24,7 @@ const headersRename = [
   "Hours",
   "PTO Hours",
   "Total",
+  "Notes",
 ];
 
 const headers = [
@@ -36,6 +37,7 @@ const headers = [
   "hours",
   "ptoHours",
   "total",
+  "notes",
 ];
 
 const filterStyles = {
@@ -80,9 +82,10 @@ export const BillingReportList = () => {
       filters={reportFilters}
       filterDefaultValues={{
         startDate: defaultStartDate,
-        endDate: defaultEndDate
+        endDate: defaultEndDate,
       }}
       disableSyncWithLocation
+      sort={{ field: "internalId", order: "ASC" }}
     >
       <Datagrid bulkActionButtons={false}>
         <ReferenceField
@@ -101,6 +104,7 @@ export const BillingReportList = () => {
         <NumberField source="hours" />
         <NumberField source="ptoHours" />
         <NumberField source="total" />
+        <TextField source="notes" />
       </Datagrid>
     </List>
   );

--- a/src/projects.tsx
+++ b/src/projects.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import {
+  BooleanField,
   Datagrid,
   DateField,
   EditButton,
@@ -39,6 +40,12 @@ const formData = [
           optionText: "name",
         },
       },
+      {
+        name: "paidPto",
+        type: "boolean",
+        defaultValue: false,
+        label: "Paid PTO",
+      },
     ],
   },
   {
@@ -66,6 +73,7 @@ export const ProjectList = () => {
         <TextField source="name" />
         <DateField source="startDate" locales={locale} />
         <DateField source="endDate" locales={locale} />
+        <BooleanField source="paidPto" label="Paid PTO" />
         <EditButton />
       </Datagrid>
     </List>


### PR DESCRIPTION
This pull request includes changes to two files, `src/billingReport.tsx` and `src/projects.tsx`, to add new fields and sorting functionality. The most important changes include adding a "notes" field to the billing report, adding a "Paid PTO" field to the projects list, and enabling sorting by "internalId" in the billing report.

Changes to `src/billingReport.tsx`:

* Added "Notes" to the `headersRename` and `headers` arrays. [[1]](diffhunk://#diff-002612cfcbcc51a94def2918bf354c16eee0cede3096b3caded8c88372b57775R27) [[2]](diffhunk://#diff-002612cfcbcc51a94def2918bf354c16eee0cede3096b3caded8c88372b57775R40)
* Enabled sorting by "internalId" in ascending order in the `BillingReportList` component.
* Added a `TextField` for the "notes" field in the `BillingReportList` component.

Changes to `src/projects.tsx`:

* Added a `BooleanField` import.
* Added a "Paid PTO" boolean field to the `formData` array.
* Added a `BooleanField` for "Paid PTO" in the `ProjectList` component.