### PR TITLE
Add export maxResults configuration for reports

### DIFF
--- a/src/billingReport.tsx
+++ b/src/billingReport.tsx
@@ -12,6 +12,7 @@ import {
 import { exporter } from "./utils/exporter";
 import * as React from "react";
 import moment from "moment";
+import { EXPORT_CONFIG } from "./utils/constants";
 
 
 const headersRename = [
@@ -76,7 +77,7 @@ export const BillingReportList = () => {
       exporter={exporter("billingReport", headers, headersRename)}
       actions={
         <>
-          <ExportButton />
+          <ExportButton maxResults={EXPORT_CONFIG.maxResults}/>
         </>
       }
       filters={reportFilters}

--- a/src/marginReport.tsx
+++ b/src/marginReport.tsx
@@ -10,6 +10,7 @@ import {
   TextField,
 } from "react-admin";
 import { exporter } from "./utils/exporter";
+import { EXPORT_CONFIG } from "./utils/constants";
 import * as React from "react";
 import moment from "moment";
 
@@ -80,7 +81,7 @@ export const MarginReportList = () => {
       exporter={exporter("marginReport", headers, headersRename)}
       actions={
         <>
-          <ExportButton />
+          <ExportButton maxResults={EXPORT_CONFIG.maxResults} />
         </>
       }
       filters={reportFilters}
@@ -101,11 +102,11 @@ export const MarginReportList = () => {
           <TextField source="internalId" />
         </ReferenceField>
         <DateField source="yearMonth"
-          options={{
-            month: 'short',
-            year: 'numeric',
-            day: undefined
-          }}
+                   options={{
+                     month: "short",
+                     year: "numeric",
+                     day: undefined,
+                   }}
         />
         <TextField source="firstName" />
         <TextField source="lastName" />

--- a/src/salaryReport.tsx
+++ b/src/salaryReport.tsx
@@ -10,6 +10,7 @@ import {
 } from "react-admin";
 import { exporter } from "./utils/exporter";
 import * as React from "react";
+import { EXPORT_CONFIG } from "./utils/constants";
 
 const headersRename = [
   "Internal ID",
@@ -47,7 +48,9 @@ export const SalariesReportList = () => {
       actions={
         <>
           {" "}
-          <FilterButton /> <ExportButton />{" "}
+          <FilterButton />
+          <ExportButton maxResults={EXPORT_CONFIG.maxResults}/>
+          {" "}
         </>
       }
       filters={employeeReportFilters}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,3 @@
+export const EXPORT_CONFIG = {
+  maxResults: 10000,
+}


### PR DESCRIPTION
This pull request introduces a new `EXPORT_CONFIG` constant to standardize the maximum number of exportable results across multiple report components. It also includes minor formatting adjustments in one of the components. 

### Standardization of Export Configuration:
* [`src/utils/constants.ts`](diffhunk://#diff-e8d0a358ae2fb090c56f00a058050983cc9691b7d3622ddd443170017123e7d9R1-R3): Added a new `EXPORT_CONFIG` constant with a `maxResults` property set to 10,000.
* `src/billingReport.tsx`, `src/marginReport.tsx`, and `src/salaryReport.tsx`: Updated the `ExportButton` in each report component to use the `EXPORT_CONFIG.maxResults` value for the `maxResults` prop. [[1]](diffhunk://#diff-002612cfcbcc51a94def2918bf354c16eee0cede3096b3caded8c88372b57775L79-R80) [[2]](diffhunk://#diff-afe65a884a836bb461534c273d39a323e70a8a3ab19a226b77435c569f542e49L83-R84) [[3]](diffhunk://#diff-2348f3c50da7be80397bf46ad5b4038892e7e0a655856dbe06f78c03d221ae7cL50-R53)

### Code Consistency:
* `src/billingReport.tsx`, `src/marginReport.tsx`, and `src/salaryReport.tsx`: Imported the new `EXPORT_CONFIG` constant in each file. [[1]](diffhunk://#diff-002612cfcbcc51a94def2918bf354c16eee0cede3096b3caded8c88372b57775R15) [[2]](diffhunk://#diff-afe65a884a836bb461534c273d39a323e70a8a3ab19a226b77435c569f542e49R13) [[3]](diffhunk://#diff-2348f3c50da7be80397bf46ad5b4038892e7e0a655856dbe06f78c03d221ae7cR13)

### Minor Formatting Adjustment:
* [`src/marginReport.tsx`](diffhunk://#diff-afe65a884a836bb461534c273d39a323e70a8a3ab19a226b77435c569f542e49L105-R108): Adjusted the formatting of the `DateField` options for consistency.