### PR TITLE
Add feedback management tab to employee profiles

### DIFF
--- a/src/employeeFeedback.tsx
+++ b/src/employeeFeedback.tsx
@@ -50,8 +50,8 @@ export const EmployeeFeedbackList = () => {
         <ReferenceField source="employeeId" reference="employees">
           <TextField source="lastName" /> <TextField source="firstName" />
         </ReferenceField>
-        <TextField source="title" />
         <TextField source="feedbackDate" />
+        <TextField source="title" />
         <SelectField source="source" choices={feedbackSourceChoices} />
         <EditButton />
       </Datagrid>

--- a/src/employeeProfiles.tsx
+++ b/src/employeeProfiles.tsx
@@ -26,6 +26,7 @@ import {
   ListContextProvider,
   SelectField,
 } from "react-admin";
+import { feedbackSourceChoices } from "./employeeFeedback";
 import {
   Avatar,
   Box,
@@ -757,6 +758,39 @@ export const EmployeeProfile = () => {
                     <CancelPtoButton id={record.id} record={record} />
                   )}
                 />
+              </Datagrid>
+            </ReferenceManyField>
+          </Tab>
+        )}
+        {HasPermissions("feedback/employee", "create") && (
+          <Tab label="Feedback">
+            <ReferenceManyField
+              label=""
+              reference="feedback/employee"
+              target="employeeId"
+              sort={{ field: "feedbackDate", order: "DESC" }}
+            >
+              <RedirectButton
+                form="create"
+                resource="feedback/employee"
+                text="+ CREATE"
+                source="employeeProfile"
+                recordId={DisplayRecordCurrentId() as string}
+              />
+              <Datagrid
+                bulkActionButtons={false}
+                empty={<CustomEmpty message="No feedback found" />}
+              >
+                <DateField source="feedbackDate" locales={locale} />
+                <TextField source="title" />
+                <SelectField source="source" choices={feedbackSourceChoices} />
+                {HasPermissions("feedback/employee", "update") && (
+                  <FunctionField
+                    render={(record) => (
+                      <EditButton />
+                    )}
+                  />
+                )}
               </Datagrid>
             </ReferenceManyField>
           </Tab>


### PR DESCRIPTION
This pull request introduces changes to enhance the employee feedback management functionality by reordering fields for consistency, reusing shared constants, and adding a new tab to display feedback in employee profiles. Below are the most important changes grouped by theme:

### Enhancements to Employee Feedback List

* Reordered the `title` field in `EmployeeFeedbackList` to maintain a consistent display order with other fields. (`src/employeeFeedback.tsx`, [src/employeeFeedback.tsxL53-R54](diffhunk://#diff-c0aa7676caca313177782388eb3cac5a654a7ab7a39a52d9c6db9897c48caea4L53-R54))

### Code Reuse and Modularity

* Imported the `feedbackSourceChoices` constant into `EmployeeProfiles` to reuse the shared list of feedback sources. (`src/employeeProfiles.tsx`, [src/employeeProfiles.tsxR29](diffhunk://#diff-67e6ddce2c5506e780fb5fcc9633fbbe1c36c77bcbd17d3b6ea8225e42d6d0e5R29))

### New Feedback Tab in Employee Profiles

* Added a "Feedback" tab in `EmployeeProfile` to display employee feedback. The tab includes a `ReferenceManyField` for listing feedback entries, a button for creating new feedback, and conditional rendering of an edit button based on user permissions. (`src/employeeProfiles.tsx`, [src/employeeProfiles.tsxR765-R797](diffhunk://#diff-67e6ddce2c5506e780fb5fcc9633fbbe1c36c77bcbd17d3b6ea8225e42d6d0e5R765-R797))