### PR TITLE
Add turnover report list with filters and export functionality

### DIFF
--- a/src/resources.ts
+++ b/src/resources.ts
@@ -38,6 +38,7 @@ import { EmployeeReportList } from "./employeesReport";
 import { SalariesReportList } from "./salaryReport";
 import { BillingReportList} from "./billingReport";
 import { MarginReportList} from "./marginReport";
+import { TurnoverReportList} from "./turnoverReport";
 import { PtosReport } from "./employeesPtosReport";
 import { OvertimeCreate, OvertimeEdit, OvertimeList, OvertimeView } from "./overtimes";
 import { EmployeeFeedbackList, EmployeeFeedbackEdit, EmployeeFeedbackCreate } from "./employeeFeedback";
@@ -207,6 +208,13 @@ export const resourceMap: {
   {
     entity: "reports/ptos/employees",
     list: PtosReport,
+    edit: undefined,
+    create: undefined,
+    show: undefined,
+  },
+  {
+    entity: "reports/turnover/flat",
+    list: TurnoverReportList,
     edit: undefined,
     create: undefined,
     show: undefined,

--- a/src/turnoverReport.tsx
+++ b/src/turnoverReport.tsx
@@ -1,0 +1,126 @@
+import {
+  Datagrid,
+  DateField,
+  DateInput,
+  ExportButton,
+  FilterButton,
+  List,
+  NumberField,
+  SearchInput,
+  SelectInput,
+  TextField,
+} from "react-admin";
+import { exporter } from "./utils/exporter";
+import { EXPORT_CONFIG } from "./utils/constants";
+import * as React from "react";
+import moment from "moment";
+
+
+const headersRename = [
+  "Level Type",
+  "Id",
+  "Name",
+  "Parent Id",
+  "Period Type",
+  "Year Month",
+  "Employees Start",
+  "Employees Left",
+  "Employees End",
+  "Turnover Rate",
+];
+
+const headers = [
+  "levelType",
+  "id",
+  "name",
+  "parentId",
+  "periodType",
+  "yearMonth",
+  "employeesStart",
+  "employeesLeft",
+  "employeesEnd",
+  "turnoverRate",
+];
+
+const filterStyles = {
+  "& .MuiInputBase-root": {
+    height: "40px",
+  },
+};
+
+const parseISODate = (val?: string | null) => val && new Date(val).toISOString().slice(0, 10);
+
+// Calculate the first day of the previous month and the last day of the previous month
+const defaultStartDate = moment().subtract(1, "month").startOf("month").format("YYYY-MM-DD");
+const defaultEndDate = moment().subtract(1, "month").endOf("month").format("YYYY-MM-DD");
+
+const reportFilters = [
+  <DateInput source="startDate"
+             alwaysOn
+             label="Start Date"
+             sx={filterStyles}
+             inputProps={{ inputFormat: "YYYY-MM-DD" }}
+             parse={parseISODate}
+  />,
+  <DateInput source="endDate"
+             alwaysOn
+             label="End Date"
+             sx={filterStyles}
+             inputProps={{ inputFormat: "YYYY-MM-DD" }}
+             parse={parseISODate}
+  />,
+  <SearchInput source="name" alwaysOn />,
+
+  <SelectInput label="Level" source="levelType" sx={filterStyles} alwaysOn
+               choices={[
+                 { id: "COMPANY", name: "Company" },
+                 { id: "CLIENT", name: "Client" },
+                 { id: "PROJECT", name: "Project" },
+               ]}
+  />,
+  <SelectInput label="Period" source="periodType" sx={filterStyles} alwaysOn
+               choices={[
+                 { id: "OVERALL", name: "Overall" },
+                 { id: "MONTHLY", name: "Monthly" },
+               ]}
+  />,
+];
+
+export const TurnoverReportList = () => {
+  return (
+    <List
+      resource="reports/turnover/flat"
+      exporter={exporter("turnoverReport", headers, headersRename)}
+      actions={
+        <>
+          <FilterButton />
+          <ExportButton maxResults={EXPORT_CONFIG.maxResults} />
+        </>
+      }
+      filters={reportFilters}
+      filterDefaultValues={{
+        startDate: defaultStartDate,
+        endDate: defaultEndDate,
+      }}
+      disableSyncWithLocation
+      // sort={{ field: "internalId", order: "ASC" }}
+    >
+      <Datagrid bulkActionButtons={false}>
+        <TextField source="levelType" />
+        <TextField source="name" />
+        <TextField source="periodType" />
+        <DateField source="yearMonth"
+                   options={{
+                     month: "short",
+                     year: "numeric",
+                     day: undefined,
+                   }}
+        />
+        <NumberField source="employeesStart" />
+        <NumberField source="employeesLeft" />
+        <NumberField source="employeesEnd" />
+        <NumberField source="turnoverRate" />
+      </Datagrid>
+    </List>
+  );
+};


### PR DESCRIPTION
Implemented a new `TurnoverReportList` component featuring filters for start date, end date, level, and period. Added default filter values for the previous month. Integrated export functionality with customizable headers. Registered the new report list in `resources.ts`.
