### PR TITLE
Employee's Date Information Reorganized

### DIFF
--- a/src/employeeProfiles.tsx
+++ b/src/employeeProfiles.tsx
@@ -238,27 +238,31 @@ export const EmployeeProfile = () => {
               <SimpleShowLayout divider={<Divider flexItem />}>
                 {!record.startDate && (
                   <>
-                    <Typography variant="subtitle2" color="textSecondary">
+                    <Typography variant="subtitle2" color="textSecondary" display="inline"  marginRight={"10px"}>
                       Start Date
                     </Typography>
-                    <span style={styleForSpan}> - </span>
-                    <Typography variant="subtitle2" color="textSecondary">
+                    <span> - </span>
+                    <p></p>
+                    <Typography variant="subtitle2" color="textSecondary" display="inline"  marginRight={"10px"}>
                       End Date
                     </Typography>
-                    <span style={styleForSpan}>-</span>
+                    <span> - </span>
                   </>
                 )}
                 {record.startDate && (
                   <>
-                    <Typography variant="subtitle2" color="textSecondary">
+                    <Typography variant="subtitle2" color="textSecondary" display="inline" marginRight={"10px"}>
                       Start Date
                     </Typography>
+
                     <DateField
-                      label=""
-                      source="startDate"
-                      record={record}
-                      locales={locale}
+                       label=""
+                       source="startDate"
+                       record={record}
+                       locales={locale}
+                       
                     />
+                    
                     <TextField
                       label=""
                       source="timeSinceStart"
@@ -269,15 +273,15 @@ export const EmployeeProfile = () => {
                 )}
                 {record.startDate && !record.endDate && (
                   <>
-                    <Typography variant="subtitle2" color="textSecondary">
+                    <Typography variant="subtitle2" color="textSecondary" display="inline"  marginRight={"10px"}>
                       End Date
                     </Typography>
-                    <span style={styleForSpan}> - </span>
+                    <span> - </span>
                   </>
                 )}
                 {record.endDate && (
                   <>
-                    <Typography variant="subtitle2" color="textSecondary">
+                    <Typography variant="subtitle2" color="textSecondary" display="inline"  marginRight={"10px"}>
                       End Date
                     </Typography>
                     <DateField


### PR DESCRIPTION
Employee's start Date Information has been reorganized:
- text content that was under "Since Start" was moved below the "Start Date" section
- the "Since Start" label has been removed
