### PR TITLE
Add 'Internal' boolean field to projects list

### DIFF
--- a/src/projects.tsx
+++ b/src/projects.tsx
@@ -46,6 +46,12 @@ const formData = [
         defaultValue: false,
         label: "Paid PTO",
       },
+      {
+        name: "isInternal",
+        type: "boolean",
+        defaultValue: false,
+        label: "Internal",
+      }
     ],
   },
   {
@@ -74,6 +80,7 @@ export const ProjectList = () => {
         <DateField source="startDate" locales={locale} />
         <DateField source="endDate" locales={locale} />
         <BooleanField source="paidPto" label="Paid PTO" />
+        <BooleanField source="isInternal" label="Internal" />
         <EditButton />
       </Datagrid>
     </List>


### PR DESCRIPTION
This pull request adds support for tracking whether a project is internal. The changes introduce a new `isInternal` boolean field to both the project form and the project list display.

Project form and display updates:

* Added a new `isInternal` boolean field to the project form data, allowing users to specify if a project is internal.
* Updated the project list view to display the `isInternal` field as a boolean column labeled "Internal".