### PR TITLE
Add ReferenceAutocompleteItem component and integrate

### DIFF
--- a/src/components/forms/FormSections.tsx
+++ b/src/components/forms/FormSections.tsx
@@ -10,6 +10,7 @@ import {
 import { Box, Typography, useMediaQuery } from "@mui/material";
 import { useWatch } from "react-hook-form";
 import ReferenceInputItem from "./ReferenceInputItem";
+import ReferenceAutocompleteItem from "./ReferenceAutocompleteItem";
 import PaymentSection from "./PaymentSection";
 import ChildrenSection from "./ChildrenSection";
 import MultiSelectInput from "./MultiSelectInput";
@@ -136,6 +137,11 @@ const FormSection = ({
                 ) : undefined}
                 {listItem.type === "selectInput" ? (
                   <ReferenceInputItem
+                    referenceValues={listItem.referenceValues}
+                  />
+                ) : undefined}
+                {listItem.type === "AutocompleteInput" ? (
+                  <ReferenceAutocompleteItem
                     referenceValues={listItem.referenceValues}
                   />
                 ) : undefined}

--- a/src/components/forms/ReferenceAutocompleteItem.tsx
+++ b/src/components/forms/ReferenceAutocompleteItem.tsx
@@ -2,6 +2,12 @@ import * as React from "react";
 import { useEffect, useState } from "react";
 import { AutocompleteInput, useDataProvider } from "react-admin";
 
+// Definición del tipo para las opciones
+export type Choice = {
+  id: number;
+  name: string;
+};
+
 const ReferenceAutocompleteItem = ({
   referenceValues,
 }: {
@@ -10,6 +16,7 @@ const ReferenceAutocompleteItem = ({
     reference: string;
     optionText: string;
     optionValue: string;
+    ItemsPerPage: number;
     required?: boolean;
   };
 }) => {
@@ -18,16 +25,17 @@ const ReferenceAutocompleteItem = ({
     reference,
     optionText,
     optionValue,
+    ItemsPerPage,
     required,
   } = referenceValues;
 
   const dataProvider = useDataProvider();
-  const [choices, setChoices] = useState<any[]>([]);
+  const [choices, setChoices] = useState<Choice[]>([]);
 
   useEffect(() => {
     dataProvider
       .getList(reference, {
-        pagination: { page: 1, perPage: 1000 },
+        pagination: { page: 1, perPage: ItemsPerPage },
         sort: { field: optionText, order: "ASC" },
         filter: {},
       })
@@ -36,7 +44,7 @@ const ReferenceAutocompleteItem = ({
         console.error("Error fetching", reference, ":", error);
         setChoices([]);
       });
-  }, [dataProvider, optionText]);
+  }, [dataProvider, optionText, reference, ItemsPerPage]);
 
   return (
     <AutocompleteInput

--- a/src/components/forms/ReferenceAutocompleteItem.tsx
+++ b/src/components/forms/ReferenceAutocompleteItem.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { useEffect, useState } from "react";
+import { AutocompleteInput, useDataProvider } from "react-admin";
+
+const ReferenceAutocompleteItem = ({
+  referenceValues,
+}: {
+  referenceValues: {
+    source: string;
+    reference: string;
+    optionText: string;
+    optionValue: string;
+    required?: boolean;
+  };
+}) => {
+  const {
+    source,
+    reference,
+    optionText,
+    optionValue,
+    required,
+  } = referenceValues;
+
+  const dataProvider = useDataProvider();
+  const [choices, setChoices] = useState<any[]>([]);
+
+  useEffect(() => {
+    dataProvider
+      .getList(reference, {
+        pagination: { page: 1, perPage: 1000 },
+        sort: { field: optionText, order: "ASC" },
+        filter: {},
+      })
+      .then(({ data }) => setChoices(data))
+      .catch((error) => {
+        console.error("Error fetching", reference, ":", error);
+        setChoices([]);
+      });
+  }, [dataProvider, optionText]);
+
+  return (
+    <AutocompleteInput
+      source={source}
+      choices={choices}
+      optionText={optionText}
+      optionValue={optionValue}
+      isRequired={required}
+      fullWidth
+    />
+  );
+};
+
+export default ReferenceAutocompleteItem;

--- a/src/components/forms/ReferenceAutocompleteItem.tsx
+++ b/src/components/forms/ReferenceAutocompleteItem.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { useEffect, useState } from "react";
 import { AutocompleteInput, useDataProvider } from "react-admin";
 
-// Definición del tipo para las opciones
 export type Choice = {
   id: number;
   name: string;

--- a/src/contracts.tsx
+++ b/src/contracts.tsx
@@ -99,6 +99,7 @@ const formData = [
           reference: "roles",
           optionText: "name",
           optionValue: "id",
+          ItemsPerPage: 100,
           required: true,
         },
       },

--- a/src/contracts.tsx
+++ b/src/contracts.tsx
@@ -93,16 +93,16 @@ const formData = [
     inputsList: [
       {
         name: "profile",
-        type: "selectInput",
+        type: "AutocompleteInput",
         referenceValues: {
           source: "roleId",
           reference: "roles",
           optionText: "name",
-          multiselect: false,
+          optionValue: "id",
           required: true,
-          sortField: "name",
         },
       },
+      
       {
         name: "seniority",
         type: "selectInput",


### PR DESCRIPTION
This pull request introduces a new autocomplete input component for reference data in forms, replacing the previous select input for the "profile" field and updating the form rendering logic to support this new input type.

**Form Input Improvements:**

* Added a new `ReferenceAutocompleteItem` component that uses `react-admin`'s `AutocompleteInput` to fetch and display reference choices dynamically. This component handles fetching data, error handling, and rendering the input. (`src/components/forms/ReferenceAutocompleteItem.tsx`)
* Updated the form rendering logic in `FormSections.tsx` to support the new "AutocompleteInput" type, rendering the `ReferenceAutocompleteItem` when specified in the form configuration. [[1]](diffhunk://#diff-904f684e3f4ff5b158e91a87f4198d0380df8f1c9a2343ca49018f8118c7f92bR143-R147) [[2]](diffhunk://#diff-904f684e3f4ff5b158e91a87f4198d0380df8f1c9a2343ca49018f8118c7f92bR13)

**Form Configuration Update:**

* Changed the "profile" field in the form configuration from `selectInput` to `AutocompleteInput`, and ensured the correct reference values are passed for dynamic option fetching. (`src/contracts.tsx`)