### PR TITLE
Enhance reimbursement export with related data

### DIFF
--- a/src/reimbursements.tsx
+++ b/src/reimbursements.tsx
@@ -7,14 +7,36 @@ import {
   NumberField, 
   DateField, 
   ReferenceField,
-  useLocaleState 
+  useLocaleState,
+  useDataProvider
 } from "react-admin";
 import CreateForm from "./components/forms/CreateForm";
 import EditForm from "./components/forms/EditForm";
+import { exporter } from "./utils/exporter";
 
 function disabledCheck(source: string) {
   return source === "employeeProfile";
 }
+
+const headers = [
+  "employee.internalId",
+  "employee.firstName",
+  "employee.lastName", 
+  "category.name",
+  "amount",
+  "date", 
+  "comment",
+];
+
+const headersRename = [
+  "Internal ID", 
+  "First Name",
+  "Last Name",
+  "Category Name",
+  "Amount",
+  "Date",
+  "Comment",
+];
 
 const formData = [
   {
@@ -54,9 +76,12 @@ const formData = [
 
 export const ReimbursementsList = () => {
   const [locale] = useLocaleState();
+  const dataProvider = useDataProvider();
   
   return (
-    <List>
+    <List
+      exporter={exporter("reimbursement", headers, headersRename, dataProvider)}
+    >
       <Datagrid rowClick="edit">
         <ReferenceField source="employeeId" reference="employees" link={false}>
           <TextField source="firstName" />

--- a/src/utils/exporter.ts
+++ b/src/utils/exporter.ts
@@ -3,13 +3,66 @@
 import * as jsonExport from "jsonexport/dist";
 
 export const exporter =
-  (entity: string, headers: any[], headersRename: any) => (records: any[]) => {
-    const recordsForExport = records.map((record) => {
-      return headers.reduce((recordForExport, field) => {
-        recordForExport[field] = record[field];
-        return recordForExport;
-      }, {});
-    });
+  (entity: string, headers: any[], headersRename: any, dataProvider?: any) => async (records: any[]) => {
+        
+    let recordsForExport = records;
+    
+    // If dataProvider is provided, fetch related data
+    if (dataProvider) {
+      // Fetch related employee data
+      const employeeIds = [...new Set(records.map(record => record.employeeId))].filter(Boolean);
+      const employees = employeeIds.length > 0 
+        ? await dataProvider.getMany('employees', { ids: employeeIds })
+        : { data: [] };
+      
+        // Fetch related category data
+      const categoryIds = [...new Set(records.map(record => record.categoryId))].filter(Boolean);
+      const categories = categoryIds.length > 0
+        ? await dataProvider.getMany('reimbursement-categories', { ids: categoryIds })
+        : { data: [] };
+
+      // Create maps for quick access
+      const employeeMap = new Map(employees.data.map((emp: any) => [emp.id, emp]));
+      const categoryMap = new Map(categories.data.map((cat: any) => [cat.id, cat]));
+      
+      recordsForExport = records.map((record) => {
+        const employee: any = employeeMap.get(record.employeeId);
+        const category: any = categoryMap.get(record.categoryId);
+        
+        return headers.reduce((recordForExport, field) => {
+          // Handle fields from related tables
+          switch (field) {
+            case 'employee.internalId':
+              recordForExport[field] = employee?.internalId || '';
+              break;
+            case 'employee.firstName':
+              recordForExport[field] = employee?.firstName || '';
+              break;
+            case 'employee.lastName':
+              recordForExport[field] = employee?.lastName || '';
+              break;
+            case 'category.name':
+              recordForExport[field] = category?.name || '';
+              break;
+            case 'category.description':
+              recordForExport[field] = category?.description || '';
+              break;
+            default:
+              // Direct field from record
+              recordForExport[field] = record[field];
+          }
+          return recordForExport;
+        }, {});
+      });
+    } else {
+      // Default behavior without dataProvider
+      recordsForExport = records.map((record) => {
+        return headers.reduce((recordForExport, field) => {
+          recordForExport[field] = record[field];
+          return recordForExport;
+        }, {});
+      });
+    }
 
     const fileName = `${entity}_${new Date().toISOString().split("T")[0]}.csv`;
 
@@ -23,8 +76,17 @@ export const exporter =
         booleanFalseString: "Inactive",
       },
       (err: any, csv: any) => {
+        // Add BOM for UTF-8 and improve encoding
+        const BOM = '\uFEFF';
+        const csvWithBOM = BOM + csv;
+
         // Export to xls
-        const blob = new Blob([csv], { type: "application/csv" });
+        //const blob = new Blob([csv], { type: "application/csv" });
+        // Create blob with explicit UTF-8 encoding
+        const blob = new Blob([csvWithBOM], { 
+          type: "text/csv;charset=utf-8;" 
+        });
+
         const url = window.URL.createObjectURL(blob);
         const a = document.createElement("a");
         a.style.display = "none";
@@ -32,6 +94,7 @@ export const exporter =
         a.download = fileName;
         document.body.appendChild(a);
         a.click();
+        document.body.removeChild(a);
         window.URL.revokeObjectURL(url);
         // Export to csv
         //downloadCSV(csv, fileName);


### PR DESCRIPTION
This pull request enhances the reimbursement export functionality by improving the CSV exporter utility to support exporting related data (such as employee and category details) and ensuring correct CSV encoding. The changes also update the `ReimbursementsList` to use the improved exporter.

**Export functionality improvements:**

* The `exporter` utility in `src/utils/exporter.ts` now supports fetching and including related employee and category data in the exported CSV by using the `dataProvider` to retrieve related records. This allows fields like `employee.firstName` and `category.name` to be included in the export.
* The exporter now adds a UTF-8 BOM to the generated CSV file and sets the correct MIME type, improving compatibility with Excel and other spreadsheet programs.

**Integration in reimbursement list:**

* The `ReimbursementsList` component in `src/reimbursements.tsx` is updated to use the enhanced exporter, passing the necessary headers, display names, and `dataProvider` to enable exporting with related data.
* Header arrays (`headers` and `headersRename`) are defined in `src/reimbursements.tsx` to specify which fields to export and their display names.