### PR TITLE
Style inactive employee names in report

### DIFF
--- a/src/salaryReport.tsx
+++ b/src/salaryReport.tsx
@@ -8,6 +8,7 @@ import {
   ReferenceField,
   SearchInput,
   TextField,
+  FunctionField,
   useGetList,
 } from "react-admin";
 import { exporter } from "./utils/exporter";
@@ -145,8 +146,18 @@ export const SalariesReportList = () => {
         >
           <TextField source="internalId" />
         </ReferenceField>
-        <TextField source="firstName" />
-        <TextField source="lastName" />
+        <FunctionField
+          label="First Name"
+          render={(record: any) => (
+            <span style={{ color: record.active === false ? 'red' : 'inherit' }}>{record.firstName}</span>
+          )}
+        />
+        <FunctionField
+          label="Last Name"
+          render={(record: any) => (
+            <span style={{ color: record.active === false ? 'red' : 'inherit' }}>{record.lastName}</span>
+          )}
+        />
         <TextField source="clientName" />
         <NumberField source="salary" />
         <TextField source="modality" />


### PR DESCRIPTION
Replace firstName/lastName TextField with FunctionField to render names in red when record.active === false, making inactive employees visually stand out. Also add FunctionField import from react-admin.

# Description :pencil:

This pull request introduces a visual enhancement to the `SalariesReportList` component by highlighting inactive users in the salary report. The main change replaces the standard display of first and last names with a custom rendering that colors the names red if the user is inactive.

Visual improvements to user status indication:

* Replaced `TextField` components for `firstName` and `lastName` with `FunctionField` components, which render the names in red when the user's `active` status is `false`. This makes it easier to identify inactive users in the report.
* Added `FunctionField` to the imports from `react-admin` in `src/salaryReport.tsx` to support the new custom rendering.

## Link to ticket :link:

[https://3.basecamp.com/5776473/buckets/37034902/card_tables/cards/9263869484](https://3.basecamp.com/5776473/buckets/37034902/card_tables/cards/9263869484)