### PR TITLE
Add feedback summary

### DIFF
--- a/src/components/buttons/FeedbackSummaryButton.tsx
+++ b/src/components/buttons/FeedbackSummaryButton.tsx
@@ -29,7 +29,7 @@ const canGenerateSummary = (
   const latestSummaryDate = new Date(latestSummary.createdAt);
 
   const hasNewerFeedback = feedbackList.some((feedback) => {
-    const feedbackDate = new Date(feedback.modifiedAt);
+    const feedbackDate = new Date(feedback.modifiedAt || feedback.createdAt);
     return feedbackDate > latestSummaryDate;
   });
 

--- a/src/components/buttons/FeedbackSummaryButton.tsx
+++ b/src/components/buttons/FeedbackSummaryButton.tsx
@@ -1,29 +1,97 @@
 import * as React from "react";
-import { Button, useNotify, useRefresh, useDataProvider } from "react-admin";
+import {
+  Button,
+  useNotify,
+  useRefresh,
+  useDataProvider,
+  Confirm,
+  useGetManyReference,
+  useGetRecordId,
+  useListContext,
+} from "react-admin";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 
-export const FeedbackSummaryButton = ({ employeeId }: { employeeId: string }) => {
+const canGenerateSummary = (
+  feedbackList: any[],
+  summaryList: any[]
+): boolean => {
+
+  if (!feedbackList || feedbackList.length === 0) {
+    return false;
+  }
+
+  if (!summaryList || summaryList.length === 0) {
+    return true;
+  }
+
+
+  const latestSummary = summaryList[0];
+  const latestSummaryDate = new Date(latestSummary.createdAt);
+
+  const hasNewerFeedback = feedbackList.some((feedback) => {
+    const feedbackDate = new Date(feedback.feedbackDate || feedback.createdAt);
+    return feedbackDate > latestSummaryDate;
+  });
+
+  return hasNewerFeedback;
+};
+
+export const FeedbackSummaryButton: React.FC = () => {
+  const employeeId = useGetRecordId();
   const notify = useNotify();
   const refresh = useRefresh();
   const dataProvider = useDataProvider();
+  const [showConfirm, setShowConfirm] = React.useState(false);
+  const [loading, setLoading] = React.useState(false);
 
-  const handleClick = async (e: React.MouseEvent) => {
-    e.stopPropagation();
+  const { data: summaryList = [] } = useListContext();
 
-    await dataProvider.create(`feedback-summary/employee/${employeeId}/generate`, {
-      data: {},
-    });
+  const { data: feedbackList = [] } = useGetManyReference("feedback/employee", {
+    target: "employeeId",
+    id: employeeId,
+    sort: { field: "feedbackDate", order: "DESC" },
+  });
 
-    notify("Summary generated successfully", { type: "success" });
-    refresh();
+  const canGenerate = canGenerateSummary(feedbackList, summaryList);
+
+  const handleGenerateSummary = async () => {
+    try {
+      setLoading(true);
+      await dataProvider.create(
+        `feedback-summary/employee/${employeeId}/generate`,
+        {
+          data: {},
+        }
+      );
+      notify("Summary generated successfully", { type: "success" });
+      refresh();
+    } catch (error: any) {
+      notify("Error generating summary", { type: "error" });
+    } finally {
+      setLoading(false);
+      setShowConfirm(false);
+    }
   };
 
   return (
-    <Button
-      label="Generate Summary"
-      onClick={handleClick}
-    >
-      <AutoAwesomeIcon />
-    </Button>
+    <>
+      <Button
+        label={loading ? "Generating..." : "Generate Summary"}
+        onClick={() => setShowConfirm(true)}
+        disabled={!canGenerate || loading}
+        style={{
+          opacity: !canGenerate || loading ? 0.5 : 1,
+        }}
+      >
+        <AutoAwesomeIcon />
+      </Button>
+      <Confirm
+        isOpen={showConfirm}
+        title="Confirm Summary Generation"
+        content="Are you sure you want to generate a new feedback summary?"
+        onConfirm={handleGenerateSummary}
+        onClose={() => setShowConfirm(false)}
+      />
+    </>
   );
 };

--- a/src/components/buttons/FeedbackSummaryButton.tsx
+++ b/src/components/buttons/FeedbackSummaryButton.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { Button, useNotify, useRefresh, useDataProvider } from "react-admin";
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+
+export const FeedbackSummaryButton = ({ employeeId }: { employeeId: string }) => {
+  const notify = useNotify();
+  const refresh = useRefresh();
+  const dataProvider = useDataProvider();
+  const [loading, setLoading] = React.useState(false);
+
+  const handleClick = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    
+    if (!employeeId) {
+      notify('Cannot generate summary: employee not found', { type: 'error' });
+      return;
+    }
+
+    setLoading(true);
+    
+    try {
+      await dataProvider.create('feedback-summary/employee/' + employeeId + '/generate', {
+        data: {},
+      });
+      
+      notify('Summary generated successfully', { type: 'success' });
+      refresh();
+    } catch (error: any) {
+      notify(
+        error?.message || 'Error generating summary',
+        { type: 'error' }
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Button
+      label="Generate Summary"
+      onClick={handleClick}
+      disabled={loading}
+    >
+      <AutoAwesomeIcon />
+    </Button>
+  );
+};

--- a/src/components/buttons/FeedbackSummaryButton.tsx
+++ b/src/components/buttons/FeedbackSummaryButton.tsx
@@ -29,7 +29,7 @@ const canGenerateSummary = (
   const latestSummaryDate = new Date(latestSummary.createdAt);
 
   const hasNewerFeedback = feedbackList.some((feedback) => {
-    const feedbackDate = new Date(feedback.feedbackDate || feedback.createdAt);
+    const feedbackDate = new Date(feedback.modifiedAt);
     return feedbackDate > latestSummaryDate;
   });
 
@@ -49,7 +49,7 @@ export const FeedbackSummaryButton: React.FC = () => {
   const { data: feedbackList = [] } = useGetManyReference("feedback/employee", {
     target: "employeeId",
     id: employeeId,
-    sort: { field: "feedbackDate", order: "DESC" },
+    sort: { field: "modifiedAt", order: "DESC" },
   });
 
   const canGenerate = canGenerateSummary(feedbackList, summaryList);

--- a/src/components/buttons/FeedbackSummaryButton.tsx
+++ b/src/components/buttons/FeedbackSummaryButton.tsx
@@ -1,45 +1,27 @@
 import * as React from "react";
 import { Button, useNotify, useRefresh, useDataProvider } from "react-admin";
-import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 
 export const FeedbackSummaryButton = ({ employeeId }: { employeeId: string }) => {
   const notify = useNotify();
   const refresh = useRefresh();
   const dataProvider = useDataProvider();
-  const [loading, setLoading] = React.useState(false);
 
   const handleClick = async (e: React.MouseEvent) => {
     e.stopPropagation();
-    
-    if (!employeeId) {
-      notify('Cannot generate summary: employee not found', { type: 'error' });
-      return;
-    }
 
-    setLoading(true);
-    
-    try {
-      await dataProvider.create('feedback-summary/employee/' + employeeId + '/generate', {
-        data: {},
-      });
-      
-      notify('Summary generated successfully', { type: 'success' });
-      refresh();
-    } catch (error: any) {
-      notify(
-        error?.message || 'Error generating summary',
-        { type: 'error' }
-      );
-    } finally {
-      setLoading(false);
-    }
+    await dataProvider.create(`feedback-summary/employee/${employeeId}/generate`, {
+      data: {},
+    });
+
+    notify("Summary generated successfully", { type: "success" });
+    refresh();
   };
 
   return (
     <Button
       label="Generate Summary"
       onClick={handleClick}
-      disabled={loading}
     >
       <AutoAwesomeIcon />
     </Button>

--- a/src/employeeProfiles.tsx
+++ b/src/employeeProfiles.tsx
@@ -31,6 +31,7 @@ import { Box, Chip, Divider, Grid, Modal, Typography } from "@mui/material";
 import RedirectButton from "./components/RedirectButton";
 import { EntityViewActions, HasPermissions } from "./components/layout/CustomActions";
 import CancelPtoButton from "./components/buttons/CancelPtoButton";
+import { FeedbackSummaryButton } from "./components/buttons/FeedbackSummaryButton";
 import { useTheme } from "@mui/material/styles";
 import { proficiencyLevel } from "./skills";
 import { engagementTypeChoices } from "./assignments";
@@ -680,6 +681,44 @@ export const EmployeeProfile = () => {
                   <FunctionField
                     render={() => (
                       <EditButton />
+                    )}
+                  />
+                )}
+              </Datagrid>
+            </ReferenceManyField>
+          </Tab>
+        )}
+        {HasPermissions("feedback-summary", "read") && (
+          <Tab label="Feedback Summaries">
+            <Box sx={{ mb: 2, mt: 1, display: 'flex', alignItems: 'center' }}>
+              <FeedbackSummaryButton employeeId={DisplayRecordCurrentId() as string} />
+            </Box>
+            <ReferenceManyField
+              label=""
+              reference="feedback-summary"
+              target="employeeId"
+              sort={{ field: "createdAt", order: "DESC" }}
+            >
+              <Datagrid
+                bulkActionButtons={false}
+                empty={<CustomEmpty message="No summaries found" />}
+                rowClick="show"
+              >
+                <DateField source="createdAt" locales={locale} />
+                <TextField
+                  source="summary"
+                  style={{
+                    display: "inline-block",
+                    maxWidth: "30em",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                />
+                {HasPermissions("feedback-summary", "read") && (
+                  <FunctionField
+                    render={() => (
+                      <ShowButton />
                     )}
                   />
                 )}

--- a/src/employeeProfiles.tsx
+++ b/src/employeeProfiles.tsx
@@ -127,7 +127,6 @@ const GetLatestAssignment = () => {
     target: "employeeId",
     id: employeeId,
   });
-  // It will be changed when the active field is added to assignments
 
   const latestAssignment = React.useMemo(() => {
     if (Array.isArray(assignments) && employee) {
@@ -686,15 +685,15 @@ export const EmployeeProfile = () => {
         )}
         {HasPermissions("feedback-summary", "read") && (
           <Tab label="Feedback Summaries">
-            <Box sx={{ mb: 2, mt: 1, display: 'flex', alignItems: 'center' }}>
-              <FeedbackSummaryButton employeeId={DisplayRecordCurrentId() as string} />
-            </Box>
             <ReferenceManyField
               label=""
               reference="feedback-summary"
               target="employeeId"
               sort={{ field: "createdAt", order: "DESC" }}
             >
+              <Box sx={{ mb: 2, mt: 1, display: 'flex', alignItems: 'center' }}>
+                <FeedbackSummaryButton />
+              </Box>
               <Datagrid
                 bulkActionButtons={false}
                 empty={<CustomEmpty message="No summaries found" />}

--- a/src/feedbackSummary.tsx
+++ b/src/feedbackSummary.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import ViewForm from "./components/forms/ViewForm";
+
+const formData = [
+  {
+    title: "Summary Information",
+    inputsList: [
+      {
+        name: "Employee",
+        type: "selectInput",
+        referenceValues: {
+          source: "employeeId",
+          reference: "employees",
+          optionText: null,
+          multiselect: false,
+          required: true,
+          disabledCheck: () => true,
+        },
+      },
+      { name: "createdAt", type: "date", required: true },
+      { name: "summary", type: "string", required: true },
+    ],
+  },
+];
+
+export const FeedbackSummaryView = () => (
+  <ViewForm formData={formData} title="Feedback Summary" resource="feedback-summary" />
+);

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -48,6 +48,7 @@ import { ReimbursementsList, ReimbursementsEdit, ReimbursementsCreate } from "./
 import { SkillsList, SkillsEdit, SkillsCreate } from "./skills";
 import { BenefitsList, BenefitsEdit, BenefitsCreate } from "./benefits";
 import { EducationLevelsList, EducationLevelsEdit, EducationLevelsCreate } from "./educationLevels";
+import { FeedbackSummaryView } from "./feedbackSummary";
 
 type Resource =
   | React.ComponentType<any>
@@ -86,6 +87,13 @@ export const resourceMap: {
     create: ClientFeedbackCreate,
     show: undefined,
     recordRepresentation: (record: { title: string }) => `${record.title}`,
+  },
+  {
+    entity: "feedback-summary",
+    list: undefined,
+    edit: undefined,
+    create: undefined,
+    show: FeedbackSummaryView,
   },
   {
     entity: "projects",


### PR DESCRIPTION
# Description :pencil:

New Components
- `feedbackSummary.tsx`: View component for displaying feedback summary details (employee, creation date, and summary text)
- `FeedbackSummaryButton.tsx`: Smart button component that validates business rules and generates summaries

Modified Files
- `resources.ts`: Added `feedback-summary` resource configuration with show view
- *`employeeProfiles.tsx`: Integrated Feedback Summaries tab with the generate button

Business Logic Implemented

The button follows these validation rules:
1. **No feedback exists** → Button disabled (cannot generate without feedback)
2. **Feedback exists, no summary exists** → Button enabled
3. **Summary exists** → Button only enabled if there's feedback newer than the latest summary timestamp


## Link to ticket :link:

https://3.basecamp.com/5776473/buckets/37034902/card_tables/cards/9336082939

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested? :microscope:

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Test Scenarios

1. **No feedback scenario**
   - Navigate to employee profile with no feedback
   - Verify "Generate Summary" button is disabled

2. **Feedback exists, no summary**
   - Navigate to employee with feedback but no summary
   - Verify button is enabled

3. **Summary exists with no newer feedback**
   - Navigate to employee with summary but no feedback after summary date
   - Verify button is disabled

4. **Summary exists with newer feedback**
   - Add new feedback after the latest summary creation date
   - Verify button is enabled

5. **Show view**
   - Click on a summary row in the Datagrid
   - Verify summary detail view displays correctly with all fields
   - Verify employee reference link works

### Test Configuration
- Browser: Edge
- Environment: Local 


