### PR TITLE
Add semaphore in employee

### DIFF
--- a/src/components/EmployeeProfileHeader.tsx
+++ b/src/components/EmployeeProfileHeader.tsx
@@ -9,6 +9,13 @@ import { ContentCopy } from "@mui/icons-material";
 import { useTheme } from "@mui/material/styles";
 import { HasPermissions } from "./layout/CustomActions";
 
+// Status color legend array
+export const STATUS_COLOR_LEGEND = [
+  { statusColor: 'GREEN', label: 'Normal / Good Standing', bgcolor: '#4caf50' },
+  { statusColor: 'YELLOW', label: 'Needs attention / at risk.', bgcolor: '#ffe70fde' },
+  { statusColor: 'RED', label: 'Critical / immediate action required.', bgcolor: '#f44336' },
+];
+
 interface EmployeeProfileHeaderProps {
   vacationAvailableDays: number;
 }
@@ -69,7 +76,10 @@ export const EmployeeProfileHeader: React.FC<EmployeeProfileHeaderProps> = ({
 }) => {
   const { palette } = useTheme();
   const [locale] = useLocaleState();
+  
+  const miVar = "GREEN"; //VAR de ejemplo, luego se reemplaza por record.statusColor
 
+  // Buscar el elemento del array que coincide con el statusColor del record
   return (
     <Box
       sx={{
@@ -81,79 +91,123 @@ export const EmployeeProfileHeader: React.FC<EmployeeProfileHeaderProps> = ({
         borderRadius: 1,
       }}
     >
-      {/* Avatar with initials */}
-      <FunctionField
-        label=""
-        render={(record) => (
-          <Avatar
-            sx={{
-              width: 56,
-              height: 56,
-              bgcolor: "#3f51b5",
-              fontSize: "1.25rem",
-              fontWeight: 600,
-              mt: 1,
-            }}
-          >
-            {record.firstName?.[0]?.toUpperCase() || ""}
-            {record.lastName?.[0]?.toUpperCase() || ""}
-          </Avatar>
-        )}
-      />
-
-      {/* Name and Email */}
-      <Box sx={{ ...metricBoxSx, minWidth: 220, justifyContent: "center" }}>
+        {/* Avatar con iniciales */}
         <FunctionField
           label=""
           render={(record) => (
-            <Typography variant="h5" fontWeight={700} sx={{ lineHeight: 1.2, mb: 0.5 }}>
-              {record.firstName} {record.lastName}
-            </Typography>
+            <Avatar
+              sx={{
+                width: 56,
+                height: 56,
+                bgcolor: "#3f51b5",
+                fontSize: "1.25rem",
+                fontWeight: 600,
+                mt: 1,
+              }}
+            >
+              {record.firstName?.[0]?.toUpperCase() || ""}
+              {record.lastName?.[0]?.toUpperCase() || ""}
+            </Avatar>
           )}
         />
-        <FunctionField
-          label=""
-          render={(record) => {
-            const labourEmail = record?.labourEmail ?? "-";
-            const canCopy = !!record?.labourEmail;
-
-            return (
-              <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-                <Typography
-                  variant="body2"
-                  sx={{ color: "text.secondary", fontSize: "0.875rem" }}
-                >
-                  {labourEmail}
-                </Typography>
-                <Tooltip title="Copy email">
-                  <IconButton
-                    size="small"
-                    disabled={!canCopy}
-                    onClick={() => {
-                      if (record?.labourEmail) {
-                        navigator.clipboard.writeText(record.labourEmail);
-                      }
-                    }}
-                    sx={{ padding: 0.25 }}
+        {/* Name and Email */}
+        <Box sx={{ ...metricBoxSx, justifyContent: "flex-start", display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
+          <FunctionField
+            label=""
+            render={(record) => {
+              const semaphore = STATUS_COLOR_LEGEND.find(l => l.statusColor === miVar);
+              const isDefault = !semaphore;
+              return (
+                <Box sx={{ display: "flex", alignItems: "flex-start" }}>
+                  <Typography variant="h5" fontWeight={700} sx={{ lineHeight: 1.2, mb: 0.5, mt: 1.5}}>
+                    {record.firstName} {record.lastName}
+                  </Typography>
+                </Box>
+              );
+            }}
+          />
+          <FunctionField
+            label=""
+            render={(record) => {
+              const labourEmail = record?.labourEmail ?? "-";
+              const canCopy = !!record?.labourEmail;
+              return (
+                <Box sx={{ display: "flex", alignItems: "flex-start", gap: 0.5, mt: '0px' }}>
+                  <Typography
+                    variant="body2"
+                    sx={{ color: "text.secondary", fontSize: "0.875rem", textAlign: "left" }}
                   >
-                    <ContentCopy sx={{ fontSize: "0.875rem" }} />
-                  </IconButton>
-                </Tooltip>
-              </Box>
-            );
-          }}
-        />
-      </Box>
+                    {labourEmail}
+                  </Typography>
+                  <Tooltip title="Copy email">
+                    <IconButton
+                      size="small"
+                      disabled={!canCopy}
+                      onClick={() => {
+                        if (record?.labourEmail) {
+                          navigator.clipboard.writeText(record.labourEmail);
+                        }
+                      }}
+                      sx={{ padding: 0.25 }}
+                    >
+                      <ContentCopy sx={{ fontSize: "0.875rem" }} />
+                    </IconButton>
+                  </Tooltip>
+                </Box>
+              );
+            }}
+          />
+        </Box>
+
+      {/* Semaphore */}
+      <FunctionField
+        label=""
+        render={(record) => {
+          const semaphore = STATUS_COLOR_LEGEND.find(l => l.statusColor === miVar);
+          const isDefault = !semaphore;
+          return (
+            <Box sx={{ mt: 1.5, display: 'flex', alignItems: 'center', gap: 1, left: 0 }}>
+              <Tooltip
+                title={isDefault ? "No Status" : semaphore.label}
+                placement="right"
+                arrow
+                slotProps={{
+                  tooltip: {
+                    sx: { fontSize: '0.9rem', p: 1.5, left: -5 }
+                  }
+                }}
+              >
+                <Box
+                  sx={{
+                    width: 40,
+                    height: 40,
+                    borderRadius: "50%",
+                    bgcolor: isDefault ? "#bdbdbd" : semaphore.bgcolor,
+                    border: "3px solid #fff",
+                    boxShadow: 2,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                />
+              </Tooltip>
+              
+            </Box>
+          );
+        }}
+      />
 
       {/* Rate */}
       <FunctionField
         label=""
         render={(record) => (
-          <MetricBox
-            label="Rate"
-            value={`$${record.rate || 0}/h`}
-            minWidth={110}
-          />
+          <Box sx={{ ml: 4 }}>
+            <MetricBox
+              label="Rate"
+              value={`$${record.rate || 0}/h`}
+              minWidth={110}
+            />
+          </Box>
         )}
       />
 

--- a/src/components/EmployeeProfileHeader.tsx
+++ b/src/components/EmployeeProfileHeader.tsx
@@ -8,13 +8,7 @@ import { Avatar, Box, Typography, SxProps, Theme, IconButton, Tooltip } from "@m
 import { ContentCopy } from "@mui/icons-material";
 import { useTheme } from "@mui/material/styles";
 import { HasPermissions } from "./layout/CustomActions";
-
-// Status color legend array
-export const STATUS_COLOR_LEGEND = [
-  { statusColor: 'GREEN', label: 'Normal / Good Standing', bgcolor: '#4caf50' },
-  { statusColor: 'YELLOW', label: 'Needs attention / at risk.', bgcolor: '#ffe70fde' },
-  { statusColor: 'RED', label: 'Critical / immediate action required.', bgcolor: '#f44336' },
-];
+import { STATUS_COLOR_LEGEND } from "../utils/constants";
 
 interface EmployeeProfileHeaderProps {
   vacationAvailableDays: number;
@@ -77,9 +71,8 @@ export const EmployeeProfileHeader: React.FC<EmployeeProfileHeaderProps> = ({
   const { palette } = useTheme();
   const [locale] = useLocaleState();
   
-  const miVar = "GREEN"; //VAR de ejemplo, luego se reemplaza por record.statusColor
+  const statusColor = "GREEN"; // Example VAR, to be replaced by record.statusColor
 
-  // Buscar el elemento del array que coincide con el statusColor del record
   return (
     <Box
       sx={{
@@ -114,17 +107,13 @@ export const EmployeeProfileHeader: React.FC<EmployeeProfileHeaderProps> = ({
         <Box sx={{ ...metricBoxSx, justifyContent: "flex-start", display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
           <FunctionField
             label=""
-            render={(record) => {
-              const semaphore = STATUS_COLOR_LEGEND.find(l => l.statusColor === miVar);
-              const isDefault = !semaphore;
-              return (
-                <Box sx={{ display: "flex", alignItems: "flex-start" }}>
-                  <Typography variant="h5" fontWeight={700} sx={{ lineHeight: 1.2, mb: 0.5, mt: 1.5}}>
-                    {record.firstName} {record.lastName}
-                  </Typography>
-                </Box>
-              );
-            }}
+            render={(record) => (
+              <Box sx={{ display: "flex", alignItems: "flex-start" }}>
+                <Typography variant="h5" fontWeight={700} sx={{ lineHeight: 1.2, mb: 0.5, mt: 1.5}}>
+                  {record.firstName} {record.lastName}
+                </Typography>
+              </Box>
+            )}
           />
           <FunctionField
             label=""
@@ -162,8 +151,8 @@ export const EmployeeProfileHeader: React.FC<EmployeeProfileHeaderProps> = ({
       {/* Semaphore */}
       <FunctionField
         label=""
-        render={(record) => {
-          const semaphore = STATUS_COLOR_LEGEND.find(l => l.statusColor === miVar);
+        render={() => {
+          const semaphore = STATUS_COLOR_LEGEND.find(l => l.statusColor === statusColor);
           const isDefault = !semaphore;
           return (
             <Box sx={{ mt: 1.5, display: 'flex', alignItems: 'center', gap: 1, left: 0 }}>

--- a/src/components/forms/ListBuilder.tsx
+++ b/src/components/forms/ListBuilder.tsx
@@ -9,9 +9,10 @@ import {
   TextField,
   FunctionField,
 } from "react-admin";
-import { IconButton, Tooltip } from "@mui/material";
+import { IconButton, Tooltip, Box } from "@mui/material";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import { HasPermissions } from "../layout/CustomActions";
+import { STATUS_COLOR_LEGEND } from "../../utils/constants";
 
 const ListBuilder = ({
   fieldsList,
@@ -109,6 +110,40 @@ const ListBuilder = ({
                 >
                   {field.children}
                 </ReferenceField>
+              );
+            case "turnoverRisk":
+              return (
+                <FunctionField
+                  key={index}
+                  label={field?.label}
+                  render={() => {
+                    //const statusColor = record.statusColor || "SILVER";
+                    const statusColor = "GREEN"; // Example VAR, to be replaced by record.statusColor
+                    const semaphore = STATUS_COLOR_LEGEND.find(l => l.statusColor === statusColor);
+                    const isDefault = !semaphore;
+                    return (
+                      <Tooltip
+                        title={isDefault ? "No Status" : semaphore.label}
+                        placement="right"
+                        arrow
+                      >
+                        <Box
+                          sx={{
+                            width: 24,
+                            height: 24,
+                            borderRadius: "50%",
+                            bgcolor: isDefault ? "#bdbdbd" : semaphore.bgcolor,
+                            border: "2px solid #fff",
+                            boxShadow: 1,
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                          }}
+                        />
+                      </Tooltip>
+                    );
+                  }}
+                />
               );
             default:
               return undefined;

--- a/src/employees.tsx
+++ b/src/employees.tsx
@@ -70,6 +70,9 @@ const COLOR_BG = [
   orange[500],
 ];
 
+//const statusColor = record.statusColor || "SILVER";
+const statusColor = "GREEN"; // Example VAR, to be replaced by record.statusColor
+
 const formData = [
   {
     title: "Personal Information",
@@ -321,6 +324,7 @@ const ActiveFilter = () => {
 
 const fieldsList = [
   { name: "internalId", type: "text" },
+  { name: "turnoverRisk", type: "turnoverRisk", label: "Turnover risk" },
   { name: "firstName", type: "text" },
   { name: "lastName", type: "text" },
   { name: "countryName", type: "text", label: "Country" },
@@ -339,6 +343,7 @@ const fieldsList = [
 
 const headersRename = [
   "internalId",
+  "Turnover risk",
   "First Name",
   "Last Name",
   "Country",
@@ -460,6 +465,7 @@ const EmployeeInformation = ({ renderAs = "list" }) => {
                           ] as string,
                           fontSize: 50,
                           margin: 2,
+                          border: `5px solid ${statusColor}`,
                         }}
                       >
                         {`${record.firstName}`.charAt(0)}

--- a/src/employeesReport.tsx
+++ b/src/employeesReport.tsx
@@ -13,12 +13,15 @@ import {
   ExportButton,
   useTheme,
 } from "react-admin";
+import { Box, Tooltip } from "@mui/material";
 import { CustomizableChipField } from "./components/fields";
 import { exporter } from "./utils/exporter";
 import QuickFilter from "./components/filters/QuickFilter";
+import { STATUS_COLOR_LEGEND } from "./utils/constants";
 
 const headersRename = [
   "Internal ID",
+  "Turnover risk",
   "First Name",
   "Last Name",
   "Labour Email",
@@ -39,6 +42,7 @@ const headersRename = [
 
 const headers = [
   "internalId",
+  "turnoverRisk",
   "firstName",
   "lastName",
   "labourEmail",
@@ -90,6 +94,37 @@ export const EmployeeReportList = () => {
     >
       <Datagrid rowSx={rowStyle} bulkActionButtons={false}>
         <TextField source="internalId" />
+        <FunctionField
+          source="statusColor"
+          label="Turnover risk"
+          render={(record) => {
+            //const statusColor = record.statusColor || "GREEN";
+            const statusColor = "GREEN"; // Example VAR, to be replaced by record.statusColor
+            const semaphore = STATUS_COLOR_LEGEND.find(l => l.statusColor === statusColor);
+            const isDefault = !semaphore;
+            return (
+              <Tooltip
+                title={isDefault ? "No Status" : semaphore.label}
+                placement="right"
+                arrow
+              >
+                <Box
+                  sx={{
+                    width: 24,
+                    height: 24,
+                    borderRadius: "50%",
+                    bgcolor: isDefault ? "#bdbdbd" : semaphore.bgcolor,
+                    border: "2px solid #fff",
+                    boxShadow: 1,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                />
+              </Tooltip>
+            );
+          }}
+        />
         <TextField source="firstName" />
         <TextField source="lastName" />
         <TextField source="labourEmail" />

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,10 @@
 export const EXPORT_CONFIG = {
   maxResults: 10000,
-}
+};
+
+export const STATUS_COLOR_LEGEND = [
+  { statusColor: 'GREEN', label: 'Normal / Good Standing', bgcolor: '#4caf50' },
+  { statusColor: 'YELLOW', label: 'Needs attention / at risk.', bgcolor: '#ffe70fde' },
+  { statusColor: 'RED', label: 'Critical / immediate action required.', bgcolor: '#f44336' },
+  { statusColor: 'SILVER', label: 'ERROR: No status found', bgcolor: '#bdbdbd' },
+];

--- a/src/utils/exporter.ts
+++ b/src/utils/exporter.ts
@@ -1,6 +1,7 @@
 // TODO: Replace with a better library typescript compatible
 // @ts-ignore
 import * as jsonExport from "jsonexport/dist";
+import { STATUS_COLOR_LEGEND } from "./constants";
 
 export const exporter =
   (entity: string, headers: any[], headersRename: any, dataProvider?: any, booleanString?: boolean) => async (records: any[]) => {
@@ -111,18 +112,15 @@ export const exporter =
             case 'project.name':
               recordForExport[field] = project?.name || '';
               break;
+            case 'turnoverRisk':
+              const statusColor = record.statusColor || "GREEN";
+              const semaphore = STATUS_COLOR_LEGEND.find(l => l.statusColor === statusColor);
+              recordForExport[field] = semaphore?.label || 'No Status';
+              break;
             default:
               // Direct field from record
               recordForExport[field] = record[field];
           }
-          return recordForExport;
-        }, {});
-      });
-    } else {
-      // Default behavior without dataProvider
-      recordsForExport = records.map((record) => {
-        return headers.reduce((recordForExport, field) => {
-          recordForExport[field] = record[field];
           return recordForExport;
         }, {});
       });


### PR DESCRIPTION
# Description :pencil:

This pull request introduces a new "Turnover risk" feature across the employee management UI and export functionality. It adds a visual semaphore indicator for turnover risk status using a color legend, updates forms and reports to display this information, and ensures the status is included in CSV exports. The changes also centralize the status color mapping in a new constant.

**Turnover risk feature implementation:**

* Added a `STATUS_COLOR_LEGEND` constant in `src/utils/constants.ts` to define the mapping between status colors, labels, and background colors.
* Updated `EmployeeProfileHeader`, `ListBuilder`, and `EmployeeReportList` components to display the turnover risk semaphore with a tooltip, using the color legend for consistent UI representation. [[1]](diffhunk://#diff-11af941ec625d6726d498277d18baec4ff48c762f23a1e86fc7035c6c1c5ba2bR151-R199) [[2]](diffhunk://#diff-37b4ad35f758f0a720864d1fa1f9a53d646e04909baa003e30c9b79278b1486bR114-R147) [[3]](diffhunk://#diff-e2b75b44fea1efecf924a428824e6f2f4e15b36b4498223543aa6afca3b08996R97-R127)

**Forms and reports integration:**

* Added a new "Turnover risk" field to employee forms and reports, including updates to `fieldsList` and `headersRename` arrays in `src/employees.tsx` and `src/employeesReport.tsx` to ensure the field is shown and exported. [[1]](diffhunk://#diff-17d991d10517722726b6ef3a06815a1f495e339ad9c1e2327824e2106d4aa1dbR327) [[2]](diffhunk://#diff-17d991d10517722726b6ef3a06815a1f495e339ad9c1e2327824e2106d4aa1dbR346) [[3]](diffhunk://#diff-e2b75b44fea1efecf924a428824e6f2f4e15b36b4498223543aa6afca3b08996R45)

**Export functionality:**

* Enhanced the CSV exporter in `src/utils/exporter.ts` to output the turnover risk label instead of the raw status code, using the centralized color legend.

**UI/UX improvements:**

* Improved layout and alignment for employee profile and list items to accommodate the new semaphore indicator, ensuring consistent and accessible display. [[1]](diffhunk://#diff-11af941ec625d6726d498277d18baec4ff48c762f23a1e86fc7035c6c1c5ba2bL103-R127) [[2]](diffhunk://#diff-17d991d10517722726b6ef3a06815a1f495e339ad9c1e2327824e2106d4aa1dbR468)

These changes lay the groundwork for dynamic turnover risk status integration by using a placeholder value (`"GREEN"`) that will later be replaced with actual data from employee records.

## Link to ticket :link:

[https://3.basecamp.com/5776473/buckets/37034902/card_tables/cards/9410657262](https://3.basecamp.com/5776473/buckets/37034902/card_tables/cards/9410657262)
