### PR TITLE
Refactor employees page layout: replace Grid with responsive Box, imp…

### DIFF
--- a/src/employees.tsx
+++ b/src/employees.tsx
@@ -38,7 +38,7 @@ import {
   green,
   orange,
 } from "@mui/material/colors";
-import { Avatar, Grid } from "@mui/material";
+import { Avatar } from "@mui/material";
 import CreateForm from "./components/forms/CreateForm";
 import EditForm from "./components/forms/EditForm";
 import { HasPermissions } from "./components/layout/CustomActions";
@@ -337,10 +337,17 @@ const EmployeeInformation = () => {
   }
 
   return (
-    <Grid container spacing={2} sx={{ marginTop: 0 }}>
+    <Box
+      sx={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))",
+        gap: 2,
+        mt: 2,
+      }}
+    >
       {(data || []).map((record) => (
         <RecordContextProvider key={record.id} value={record}>
-          <Grid xs={2} item>
+          <Box sx={{ maxWidth: 480, width: "100%" }}>
             <Card>
               <CardActionArea
                 component={Link}
@@ -445,11 +452,9 @@ const EmployeeInformation = () => {
                     <Typography variant="body2" noWrap sx={{ mt: 0.5 }}>
                       Vacations: {record.availableDays ?? 0} days
                     </Typography>
-                    {record.nearestPto && (
-                      <Typography variant="body2" color="text.secondary" noWrap>
-                        Next PTO: <DateField source="nearestPto" locales={locale} />
-                      </Typography>
-                    )}
+                    <Typography variant="body2" color="text.secondary" noWrap sx={{ visibility: record.nearestPto ? "visible" : "hidden" }}>
+                      Next PTO: <DateField source="nearestPto" locales={locale} />
+                    </Typography>
                   </Box>
                 </CardContent>
               </CardActionArea>
@@ -458,10 +463,10 @@ const EmployeeInformation = () => {
                 {HasPermissions("employees", "update") && <EditButton />}
               </CardActions>
             </Card>
-          </Grid>
+          </Box>
         </RecordContextProvider>
       ))}
-    </Grid>
+    </Box>
   );
 };
 


### PR DESCRIPTION
This pull request updates the `EmployeeInformation` component in `src/employees.tsx` to improve layout responsiveness and simplify conditional rendering. The most significant changes include switching from MUI's `Grid` layout to a CSS grid using `Box`, and updating how the "Next PTO" field is displayed.

**Layout Improvements:**

* Replaced the use of MUI's `Grid` with a `Box` component that uses CSS grid for a more responsive and flexible layout. This change affects the overall container and each employee card. [[1]](diffhunk://#diff-17d991d10517722726b6ef3a06815a1f495e339ad9c1e2327824e2106d4aa1dbL340-R350) [[2]](diffhunk://#diff-17d991d10517722726b6ef3a06815a1f495e339ad9c1e2327824e2106d4aa1dbL461-R469)
* Removed the unused `Grid` import from `@mui/material` as it is no longer needed.

**UI/Rendering Adjustments:**

* Changed the conditional rendering of the "Next PTO" field: instead of conditionally rendering the `<Typography>` component, it is always rendered but its visibility is toggled using the `visibility` CSS property based on whether `record.nearestPto` exists. This prevents layout shifts when the field is not present.