### PR TITLE
Add address copy button and style education fields

### DIFF
--- a/src/components/forms/EducationSection.tsx
+++ b/src/components/forms/EducationSection.tsx
@@ -69,24 +69,40 @@ export const EducationLevelField = () => {
   const levelName = selectedLevel?.name;
   
   if (!educationLevelId) {
-    return <span className="css-e784if-MuiTypography-root">-</span>;
+    return <Typography variant="body2" component="span">-</Typography>;
   }
   
   if (levelName === "Other (Optional)" && record?.education?.levelOther) {
-    return <span className="css-e784if-MuiTypography-root">Other: {record.education.levelOther}</span>;
+    return (
+      <Typography variant="body2" component="span">
+        Other: {record.education.levelOther}
+      </Typography>
+    );
   }
   
-  return <span className="css-e784if-MuiTypography-root">{levelName || "-"}</span>;
+  return (
+    <Typography variant="body2" component="span">
+      {levelName || "-"}
+    </Typography>
+  );
 };
 
 export const EducationInstitutionField = () => {
   const record = useRecordContext();
-  return <span className="css-e784if-MuiTypography-root">{record?.education?.institution || "-"}</span>;
+  return (
+    <Typography variant="body2" component="span">
+      {record?.education?.institution || "-"}
+    </Typography>
+  );
 };
 
 export const EducationDegreeField = () => {
   const record = useRecordContext();
-  return <span className="css-e784if-MuiTypography-root">{record?.education?.degree || "-"}</span>;
+  return (
+    <Typography variant="body2" component="span">
+      {record?.education?.degree || "-"}
+    </Typography>
+  );
 };
 
 export const EducationIterator = () => {

--- a/src/components/forms/EducationSection.tsx
+++ b/src/components/forms/EducationSection.tsx
@@ -69,24 +69,24 @@ export const EducationLevelField = () => {
   const levelName = selectedLevel?.name;
   
   if (!educationLevelId) {
-    return <span>-</span>;
+    return <span className="css-e784if-MuiTypography-root">-</span>;
   }
   
   if (levelName === "Other (Optional)" && record?.education?.levelOther) {
-    return <span>Other: {record.education.levelOther}</span>;
+    return <span className="css-e784if-MuiTypography-root">Other: {record.education.levelOther}</span>;
   }
   
-  return <span>{levelName || "-"}</span>;
+  return <span className="css-e784if-MuiTypography-root">{levelName || "-"}</span>;
 };
 
 export const EducationInstitutionField = () => {
   const record = useRecordContext();
-  return <span>{record?.education?.institution || "-"}</span>;
+  return <span className="css-e784if-MuiTypography-root">{record?.education?.institution || "-"}</span>;
 };
 
 export const EducationDegreeField = () => {
   const record = useRecordContext();
-  return <span>{record?.education?.degree || "-"}</span>;
+  return <span className="css-e784if-MuiTypography-root">{record?.education?.degree || "-"}</span>;
 };
 
 export const EducationIterator = () => {

--- a/src/employeeProfiles.tsx
+++ b/src/employeeProfiles.tsx
@@ -20,6 +20,7 @@ import {
   Tab,
   TabbedShowLayout,
   TextField,
+  useNotify,
   useRecordContext,
   useGetManyReference,
   useGetOne,
@@ -43,6 +44,7 @@ import { EducationLevelField, EducationInstitutionField, EducationDegreeField } 
 
 const AddressCopyButton = () => {
   const record = useRecordContext();
+  const notify = useNotify();
   const { data: country } = useGetOne(
     "countries",
     { id: record?.countryId },
@@ -70,6 +72,7 @@ const AddressCopyButton = () => {
 
     try {
       await navigator.clipboard.writeText(addressText);
+      notify("Address copied to clipboard", { type: "info" });
     } catch {
       const textArea = document.createElement("textarea");
       textArea.value = addressText;
@@ -87,7 +90,11 @@ const AddressCopyButton = () => {
       try {
         textArea.focus();
         textArea.select();
-        document.execCommand("copy");
+        const copied = document.execCommand("copy");
+        notify(
+          copied ? "Address copied to clipboard" : "Could not copy address",
+          { type: copied ? "info" : "warning" },
+        );
       } finally {
         document.body.removeChild(textArea);
       }
@@ -297,13 +304,15 @@ export const EmployeeProfile = () => {
                 <TextField source="taxId" />
                 <WrapperField
                   label={(
-                    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, fontSize: "0.75rem" }}>
-                      <span >Address</span>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                      <Typography variant="caption" component="span">
+                        Address
+                      </Typography>
                       <AddressCopyButton />
                     </Box>
                   )}
                 >
-                <TextField source="address" />
+                  <TextField source="address" />
                 </WrapperField>
                 <TextField source="city" />
                 <ReferenceField

--- a/src/employeeProfiles.tsx
+++ b/src/employeeProfiles.tsx
@@ -61,9 +61,10 @@ const AddressCopyButton = () => {
   ]
     .filter(Boolean)
     .join(", ");
+  const canCopy = Boolean(addressText);
 
   const copyAddress = async () => {
-    if (!addressText) {
+    if (!canCopy) {
       return;
     }
 
@@ -72,18 +73,40 @@ const AddressCopyButton = () => {
     } catch {
       const textArea = document.createElement("textarea");
       textArea.value = addressText;
+      textArea.readOnly = true;
+      textArea.setAttribute("aria-hidden", "true");
+      textArea.style.position = "fixed";
+      textArea.style.top = "0";
+      textArea.style.left = "0";
+      textArea.style.width = "1px";
+      textArea.style.height = "1px";
+      textArea.style.opacity = "0";
+      textArea.style.pointerEvents = "none";
+
       document.body.appendChild(textArea);
-      textArea.select();
-      document.execCommand("copy");
-      document.body.removeChild(textArea);
+      try {
+        textArea.focus();
+        textArea.select();
+        document.execCommand("copy");
+      } finally {
+        document.body.removeChild(textArea);
+      }
     }
   };
 
   return (
-    <Tooltip title="Copy address">
-      <IconButton size="small" onClick={copyAddress} aria-label="Copy address">
-        <ContentCopyIcon fontSize="inherit" />
-      </IconButton>
+    <Tooltip title={canCopy ? "Copy address" : "No address available to copy"}>
+      <span>
+        <IconButton
+          size="small"
+          onClick={copyAddress}
+          aria-label="Copy address"
+          disabled={!canCopy}
+          sx={{ padding: 0.25 }}
+        >
+          <ContentCopyIcon sx={{ fontSize: "0.875rem" }} />
+        </IconButton>
+      </span>
     </Tooltip>
   );
 };

--- a/src/employeeProfiles.tsx
+++ b/src/employeeProfiles.tsx
@@ -20,6 +20,7 @@ import {
   Tab,
   TabbedShowLayout,
   TextField,
+  useRecordContext,
   useGetManyReference,
   useGetOne,
   useGetRecordId,
@@ -28,7 +29,8 @@ import {
   WrapperField,
 } from "react-admin";
 import { feedbackSourceChoices } from "./employeeFeedback";
-import { Box, Chip, Divider, Grid, Modal, Typography } from "@mui/material";
+import { Box, Chip, Divider, Grid, IconButton, Modal, Tooltip, Typography } from "@mui/material";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import RedirectButton from "./components/RedirectButton";
 import { EntityViewActions, HasPermissions } from "./components/layout/CustomActions";
 import CancelPtoButton from "./components/buttons/CancelPtoButton";
@@ -38,6 +40,53 @@ import { proficiencyLevel } from "./skills";
 import { engagementTypeChoices } from "./assignments";
 import { EmployeeProfileHeader } from "./components/EmployeeProfileHeader";
 import { EducationLevelField, EducationInstitutionField, EducationDegreeField } from "./components/forms/EducationSection";
+
+const AddressCopyButton = () => {
+  const record = useRecordContext();
+  const { data: country } = useGetOne(
+    "countries",
+    { id: record?.countryId },
+    { enabled: !!record?.countryId },
+  );
+
+  if (!record) {
+    return null;
+  }
+
+  const addressText = [
+    record.address,
+    record.city,
+    record.zip,
+    country?.name,
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  const copyAddress = async () => {
+    if (!addressText) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(addressText);
+    } catch {
+      const textArea = document.createElement("textarea");
+      textArea.value = addressText;
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textArea);
+    }
+  };
+
+  return (
+    <Tooltip title="Copy address">
+      <IconButton size="small" onClick={copyAddress} aria-label="Copy address">
+        <ContentCopyIcon fontSize="inherit" />
+      </IconButton>
+    </Tooltip>
+  );
+};
 
 const DisplayRecordCurrentId = () => {
   return useGetRecordId();
@@ -223,7 +272,16 @@ export const EmployeeProfile = () => {
                 />
                 <DateField source="birthDate" locales={locale} />
                 <TextField source="taxId" />
+                <WrapperField
+                  label={(
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, fontSize: "0.75rem" }}>
+                      <span >Address</span>
+                      <AddressCopyButton />
+                    </Box>
+                  )}
+                >
                 <TextField source="address" />
+                </WrapperField>
                 <TextField source="city" />
                 <ReferenceField
                   source="countryId"


### PR DESCRIPTION
Add a reusable AddressCopyButton to employeeProfiles which copies the formatted address (with country lookup) to the clipboard with a fallback textarea method. Wire the button into the address field label via WrapperField and add necessary imports (useRecordContext, IconButton, Tooltip, ContentCopyIcon, useGetOne). Also standardize education display spans in EducationSection by adding a Typography root className to ensure consistent styling.

# Description :pencil:

This pull request introduces a new feature to the employee profile page: a button for copying the full address to the clipboard. It also standardizes the appearance of certain fields by applying a consistent typography class. The most important changes are grouped below.

**New Feature: Address Copy Button**

* Added an `AddressCopyButton` component that allows users to copy the full address (including street, city, zip, and country) to the clipboard, with a fallback for older browsers. The button is displayed next to the address label in the employee profile. [[1]](diffhunk://#diff-67e6ddce2c5506e780fb5fcc9633fbbe1c36c77bcbd17d3b6ea8225e42d6d0e5R44-R90) [[2]](diffhunk://#diff-67e6ddce2c5506e780fb5fcc9633fbbe1c36c77bcbd17d3b6ea8225e42d6d0e5R275-R284)
* Updated imports to include necessary Material UI components and icons for the copy button functionality. [[1]](diffhunk://#diff-67e6ddce2c5506e780fb5fcc9633fbbe1c36c77bcbd17d3b6ea8225e42d6d0e5L31-R33) [[2]](diffhunk://#diff-67e6ddce2c5506e780fb5fcc9633fbbe1c36c77bcbd17d3b6ea8225e42d6d0e5R23)

**UI Consistency Improvements**

* Updated `EducationLevelField`, `EducationInstitutionField`, and `EducationDegreeField` components to apply the `css-e784if-MuiTypography-root` class, ensuring consistent typography for these fields.

## Link to ticket :link:

[https://3.basecamp.com/5776473/buckets/37034902/card_tables/cards/7449291565]((https://3.basecamp.com/5776473/buckets/37034902/card_tables/cards/7449291565))