### PR TITLE
Add Payroll module UI: list, trigger dialog, polling, item edit

### DIFF
--- a/src/components/layout/CustomMenu.tsx
+++ b/src/components/layout/CustomMenu.tsx
@@ -19,6 +19,7 @@ import MoreTimeIcon from '@mui/icons-material/MoreTime';
 import ForumIcon from '@mui/icons-material/Forum';
 import ReceiptIcon from '@mui/icons-material/Receipt';
 import StarIcon from '@mui/icons-material/Star';
+import PaymentsIcon from '@mui/icons-material/Payments';
 
 import {
   TreeItem2Content,
@@ -46,6 +47,7 @@ const icons: Record<string, React.ElementType> = {
   feedback: ForumIcon,
   reimbursements: ReceiptIcon,
   skills: StarIcon,
+  "payroll-runs": PaymentsIcon,
 };
 
 const CustomTreeItemRoot = styled(TreeItem2Root)(({ theme }) => ({

--- a/src/hooks/usePayrollRunStatus.ts
+++ b/src/hooks/usePayrollRunStatus.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { useDataProvider } from "react-admin";
+
+const POLL_INTERVAL_MS = 2000;
+
+/**
+ * Polls /payroll-runs/{id} every 2s until the run leaves the RUNNING state. We don't have a
+ * websocket layer in Entroteam yet, so this is the cheapest way to update the FE when the async
+ * job finishes. Each poll decides whether to schedule the next one from its own fresh response,
+ * so polling stops as soon as the run reaches a terminal status (no stale-closure leak).
+ */
+export function usePayrollRunStatus(runId: string | undefined): {
+  data: any;
+  isPolling: boolean;
+} {
+  const dataProvider = useDataProvider();
+  const [data, setData] = useState<any>(null);
+  const [isPolling, setIsPolling] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!runId) {
+      setData(null);
+      setIsPolling(false);
+      return;
+    }
+
+    let cancelled = false;
+    let timeout: number | undefined;
+
+    const poll = async () => {
+      try {
+        const response = await dataProvider.getOne("payroll-runs", { id: runId });
+        if (cancelled) return;
+        setData(response.data);
+        if (response.data?.status === "RUNNING") {
+          timeout = window.setTimeout(poll, POLL_INTERVAL_MS);
+        } else {
+          setIsPolling(false);
+        }
+      } catch (e) {
+        if (!cancelled) setIsPolling(false);
+      }
+    };
+
+    setIsPolling(true);
+    poll();
+
+    return () => {
+      cancelled = true;
+      if (timeout !== undefined) window.clearTimeout(timeout);
+    };
+  }, [runId, dataProvider]);
+
+  return { data, isPolling };
+}

--- a/src/payrollRuns.tsx
+++ b/src/payrollRuns.tsx
@@ -96,7 +96,7 @@ const TriggerDialog: React.FC<{
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Run Payroll Liquidation</DialogTitle>
+      <DialogTitle>Run Payroll</DialogTitle>
       <DialogContent>
         <Stack spacing={2} mt={1}>
           <Stack direction="row" spacing={2}>
@@ -118,7 +118,7 @@ const TriggerDialog: React.FC<{
       <DialogActions>
         <Button onClick={onClose} disabled={submitting}>Cancel</Button>
         <Button onClick={trigger} variant="contained" disabled={submitting}>
-          {submitting ? "Starting…" : "Liquidar Sueldos"}
+          {submitting ? "Starting…" : "Run Payroll"}
         </Button>
       </DialogActions>
     </Dialog>
@@ -128,12 +128,12 @@ const TriggerDialog: React.FC<{
 const PayrollRunsListActions: React.FC<{ onClickTrigger: () => void }> = ({ onClickTrigger }) => (
   <TopToolbar>
     <Button startIcon={<PaymentsIcon />} onClick={onClickTrigger} variant="contained">
-      Liquidar Sueldos
+      Run Payroll
     </Button>
   </TopToolbar>
 );
 
-const StatusChip: React.FC = () => {
+const StatusChip: React.FC<{ label?: string }> = () => {
   const record = useRecordContext();
   if (!record) return null;
   return (
@@ -145,6 +145,16 @@ const StatusChip: React.FC = () => {
   );
 };
 
+const formatPeriod = (period?: string): string => {
+  if (!period) return "";
+  const [y, m] = period.split("-").map(Number);
+  if (!y || !m) return period;
+  return `${MONTHS[m - 1]} ${y}`;
+};
+
+const USD = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
+const CURRENCY_OPTS = { style: "currency" as const, currency: "USD" };
+
 const isAdmin = (): boolean => {
   try {
     const cfg = JSON.parse(localStorage.getItem("config") || "{}");
@@ -154,7 +164,7 @@ const isAdmin = (): boolean => {
   }
 };
 
-const RowActions: React.FC = () => {
+const RowActions: React.FC<{ label?: string }> = () => {
   const record = useRecordContext();
   const dataProvider = useDataProvider();
   const notify = useNotify();
@@ -247,12 +257,12 @@ export const PayrollRunsList: React.FC = () => {
           bulkActionButtons={false}
         >
           <DateField source="period" />
-          <StatusChip />
+          <StatusChip label="Status" />
           <TextField source="triggeredByEmail" label="Triggered by" />
           <DateField source="completedAt" showTime />
           <NumberField source="employeeCount" label="Employees" />
-          <NumberField source="totalAmount" options={{ style: "currency", currency: "USD" }} />
-          <RowActions />
+          <NumberField source="totalAmount" label="Total" options={CURRENCY_OPTS} />
+          <RowActions label="" />
         </Datagrid>
       </List>
       <TriggerDialog
@@ -283,11 +293,13 @@ const PayrollRunHeader: React.FC<{ run: any }> = ({ run }) => {
   if (!run) return null;
   return (
     <Box mb={2}>
-      <Typography variant="h5">Payroll · {run.period}</Typography>
+      <Typography variant="h5">Payroll — {formatPeriod(run.period)}</Typography>
       <Stack direction="row" spacing={2} mt={1} alignItems="center">
         <Chip label={run.status} color={STATUS_COLORS[run.status] || "default"} />
         <Typography variant="body2">Employees: {run.employeeCount ?? "–"}</Typography>
-        <Typography variant="body2">Total: {run.totalAmount ?? "–"}</Typography>
+        <Typography variant="body2">
+          Total: {run.totalAmount != null ? USD.format(Number(run.totalAmount)) : "–"}
+        </Typography>
         {run.errorMessage && (
           <Alert severity="error" sx={{ ml: 2 }}>
             {run.errorMessage}
@@ -373,7 +385,10 @@ export const PayrollRunShow: React.FC = () => {
         <Button startIcon={<ArrowBackIcon />} onClick={() => navigate("/payroll-runs")}>
           Back
         </Button>
-        <Button onClick={() => exporter(`payroll-${run.period}`, itemsExportHeaders, itemsExportLabels)(items)}>
+        <Button
+          variant="outlined"
+          onClick={() => exporter(`payroll-${run.period}`, itemsExportHeaders, itemsExportLabels)(items)}
+        >
           Export CSV
         </Button>
       </Stack>
@@ -396,19 +411,19 @@ export const PayrollRunShow: React.FC = () => {
         <TextField source="firstName" label="First Name" />
         <TextField source="lastName" label="Last Name" />
         <TextField source="clientName" label="Client" />
-        <TextField source="modality" />
-        <NumberField source="baseSalary" label="Base" />
-        <NumberField source="proportionalSalary" label="Proportional" />
+        <TextField source="modality" label="Modality" />
+        <NumberField source="baseSalary" label="Base" options={CURRENCY_OPTS} />
+        <NumberField source="proportionalSalary" label="Proportional" options={CURRENCY_OPTS} />
         <NumberField source="billableHoursInMonth" label="Billable Hrs" />
         <NumberField source="overtimeHours" label="OT Hrs" />
-        <NumberField source="overtimeAmount" label="OT $" />
-        <NumberField source="reimbursementsAmount" label="Reimb" />
-        <NumberField source="vacationCashout" label="Vacation" />
-        <NumberField source="hardwareClawback" label="HW Clawback" />
-        <NumberField source="adjustment" label="Adjustment" />
-        <NumberField source="previousBalance" label="Prev Bal" />
-        <NumberField source="totalAmount" label="Total" />
-        <TextField source="notes" />
+        <NumberField source="overtimeAmount" label="OT $" options={CURRENCY_OPTS} />
+        <NumberField source="reimbursementsAmount" label="Reimb" options={CURRENCY_OPTS} />
+        <NumberField source="vacationCashout" label="Vacation" options={CURRENCY_OPTS} />
+        <NumberField source="hardwareClawback" label="HW Clawback" options={CURRENCY_OPTS} />
+        <NumberField source="adjustment" label="Adjustment" options={CURRENCY_OPTS} />
+        <NumberField source="previousBalance" label="Prev Bal" options={CURRENCY_OPTS} />
+        <NumberField source="totalAmount" label="Total" options={CURRENCY_OPTS} />
+        <TextField source="notes" label="Notes" />
         <TextField source="calculationError" label="Error" />
       </Datagrid>
     </Box>

--- a/src/payrollRuns.tsx
+++ b/src/payrollRuns.tsx
@@ -1,0 +1,435 @@
+import * as React from "react";
+import {
+  Datagrid,
+  DateField,
+  Edit,
+  Identifier,
+  List,
+  NumberField,
+  NumberInput,
+  RaRecord,
+  SimpleForm,
+  TextField,
+  TextInput,
+  TopToolbar,
+  useDataProvider,
+  useGetOne,
+  useNotify,
+  useRecordContext,
+  useRedirect,
+  useRefresh,
+} from "react-admin";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import PaymentsIcon from "@mui/icons-material/Payments";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import DeleteIcon from "@mui/icons-material/Delete";
+import ReplayIcon from "@mui/icons-material/Replay";
+import { exporter } from "./utils/exporter";
+import { usePayrollRunStatus } from "./hooks/usePayrollRunStatus";
+
+const STATUS_COLORS: Record<string, "default" | "info" | "warning" | "success" | "error"> = {
+  RUNNING: "info",
+  DRAFT: "default",
+  APPROVED: "success",
+  CLOSED: "default",
+  FAILED: "error",
+};
+
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+// ---------- List screen + trigger dialog ---------------------------------------------------------
+
+const TriggerDialog: React.FC<{
+  open: boolean;
+  onClose: () => void;
+  onTriggered: (newRunId: string) => void;
+}> = ({ open, onClose, onTriggered }) => {
+  const dataProvider = useDataProvider();
+  const notify = useNotify();
+  const today = new Date();
+  const [year, setYear] = React.useState<number>(today.getFullYear());
+  const [month, setMonth] = React.useState<number>(today.getMonth() + 1);
+  const [submitting, setSubmitting] = React.useState(false);
+
+  const trigger = async () => {
+    setSubmitting(true);
+    try {
+      const period = `${year}-${String(month).padStart(2, "0")}-01`;
+      const response = await dataProvider.create("payroll-runs", { data: { period } });
+      notify("Payroll run started", { type: "success" });
+      onTriggered((response.data as any).id);
+      onClose();
+    } catch (e: any) {
+      notify(`Could not start payroll run: ${e?.message ?? "unknown error"}`, { type: "error" });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const yearOptions = React.useMemo(() => {
+    const options: number[] = [];
+    for (let y = today.getFullYear() + 1; y >= today.getFullYear() - 4; y--) options.push(y);
+    return options;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Run Payroll Liquidation</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} mt={1}>
+          <Stack direction="row" spacing={2}>
+            <FormControl fullWidth>
+              <InputLabel>Year</InputLabel>
+              <Select label="Year" value={year} onChange={e => setYear(Number(e.target.value))}>
+                {yearOptions.map(y => <MenuItem key={y} value={y}>{y}</MenuItem>)}
+              </Select>
+            </FormControl>
+            <FormControl fullWidth>
+              <InputLabel>Month</InputLabel>
+              <Select label="Month" value={month} onChange={e => setMonth(Number(e.target.value))}>
+                {MONTHS.map((name, idx) => <MenuItem key={idx} value={idx + 1}>{name}</MenuItem>)}
+              </Select>
+            </FormControl>
+          </Stack>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={submitting}>Cancel</Button>
+        <Button onClick={trigger} variant="contained" disabled={submitting}>
+          {submitting ? "Starting…" : "Liquidar Sueldos"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+const PayrollRunsListActions: React.FC<{ onClickTrigger: () => void }> = ({ onClickTrigger }) => (
+  <TopToolbar>
+    <Button startIcon={<PaymentsIcon />} onClick={onClickTrigger} variant="contained">
+      Liquidar Sueldos
+    </Button>
+  </TopToolbar>
+);
+
+const StatusChip: React.FC = () => {
+  const record = useRecordContext();
+  if (!record) return null;
+  return (
+    <Chip
+      label={record.status}
+      color={STATUS_COLORS[record.status as string] || "default"}
+      size="small"
+    />
+  );
+};
+
+const isAdmin = (): boolean => {
+  try {
+    const cfg = JSON.parse(localStorage.getItem("config") || "{}");
+    return cfg?.role === "ROLE_ADMIN";
+  } catch {
+    return false;
+  }
+};
+
+const RowActions: React.FC = () => {
+  const record = useRecordContext();
+  const dataProvider = useDataProvider();
+  const notify = useNotify();
+  const refresh = useRefresh();
+  const navigate = useNavigate();
+  const [busy, setBusy] = React.useState(false);
+
+  if (!record) return null;
+
+  const admin = isAdmin();
+  const status = record.status as string;
+  const canDelete = status === "DRAFT" || status === "FAILED"
+    || (admin && (status === "APPROVED" || status === "CLOSED"));
+  const canRecalculate = status === "DRAFT" || status === "FAILED";
+
+  const stop = (e: React.MouseEvent) => e.stopPropagation();
+
+  const handleRecalculate = async (e: React.MouseEvent) => {
+    stop(e);
+    if (!window.confirm(`Recalculate payroll run for ${record.period}? Existing items will be replaced.`)) return;
+    setBusy(true);
+    try {
+      const response = await dataProvider.create("payroll-runs", { data: { period: record.period } });
+      notify("Payroll run recalculation started", { type: "success" });
+      const newId = (response.data as any)?.id;
+      if (newId) {
+        navigate(`/payroll-runs/${newId}/show`);
+      } else {
+        refresh();
+      }
+    } catch (err: any) {
+      notify(`Recalculate failed: ${err?.message ?? "unknown error"}`, { type: "error" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDelete = async (e: React.MouseEvent) => {
+    stop(e);
+    if (!window.confirm(`Delete payroll run for ${record.period}?`)) return;
+    setBusy(true);
+    try {
+      await dataProvider.delete("payroll-runs", { id: record.id, previousData: record });
+      notify("Payroll run deleted", { type: "success" });
+      refresh();
+    } catch (err: any) {
+      notify(`Delete failed: ${err?.message ?? "unknown error"}`, { type: "error" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Stack direction="row" spacing={0.5} onClick={stop}>
+      {canRecalculate && (
+        <Tooltip title="Recalculate">
+          <span>
+            <IconButton size="small" onClick={handleRecalculate} disabled={busy}>
+              <ReplayIcon fontSize="small" />
+            </IconButton>
+          </span>
+        </Tooltip>
+      )}
+      {canDelete && (
+        <Tooltip title="Delete">
+          <span>
+            <IconButton size="small" color="error" onClick={handleDelete} disabled={busy}>
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </span>
+        </Tooltip>
+      )}
+    </Stack>
+  );
+};
+
+export const PayrollRunsList: React.FC = () => {
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <List
+        actions={<PayrollRunsListActions onClickTrigger={() => setDialogOpen(true)} />}
+        sort={{ field: "period", order: "DESC" }}
+        empty={false}
+      >
+        <Datagrid
+          rowClick={(id) => { navigate(`/payroll-runs/${id}/show`); return false; }}
+          bulkActionButtons={false}
+        >
+          <DateField source="period" />
+          <StatusChip />
+          <TextField source="triggeredByEmail" label="Triggered by" />
+          <DateField source="completedAt" showTime />
+          <NumberField source="employeeCount" label="Employees" />
+          <NumberField source="totalAmount" options={{ style: "currency", currency: "USD" }} />
+          <RowActions />
+        </Datagrid>
+      </List>
+      <TriggerDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        onTriggered={(id) => navigate(`/payroll-runs/${id}/show`)}
+      />
+    </>
+  );
+};
+
+// ---------- Show screen (status banner + items table) --------------------------------------------
+
+const itemsExportHeaders = [
+  "internalId", "firstName", "lastName", "clientName", "modality",
+  "baseSalary", "proportionalSalary", "billableHoursInMonth", "overtimeHours", "overtimeAmount",
+  "reimbursementsAmount", "vacationCashout", "hardwareClawback",
+  "adjustment", "previousBalance", "totalAmount", "notes",
+];
+const itemsExportLabels = [
+  "Internal ID", "First Name", "Last Name", "Client", "Modality",
+  "Base", "Proportional", "Billable Hours", "OT Hours", "OT Amount",
+  "Reimbursements", "Vacation Cashout", "Hardware Clawback",
+  "Adjustment", "Previous Balance", "Total", "Notes",
+];
+
+const PayrollRunHeader: React.FC<{ run: any }> = ({ run }) => {
+  if (!run) return null;
+  return (
+    <Box mb={2}>
+      <Typography variant="h5">Payroll · {run.period}</Typography>
+      <Stack direction="row" spacing={2} mt={1} alignItems="center">
+        <Chip label={run.status} color={STATUS_COLORS[run.status] || "default"} />
+        <Typography variant="body2">Employees: {run.employeeCount ?? "–"}</Typography>
+        <Typography variant="body2">Total: {run.totalAmount ?? "–"}</Typography>
+        {run.errorMessage && (
+          <Alert severity="error" sx={{ ml: 2 }}>
+            {run.errorMessage}
+          </Alert>
+        )}
+      </Stack>
+    </Box>
+  );
+};
+
+const RunActions: React.FC<{ run: any; onChange: () => void }> = ({ run, onChange }) => {
+  const dataProvider = useDataProvider();
+  const notify = useNotify();
+  const refresh = useRefresh();
+  const redirect = useRedirect();
+  const admin = isAdmin();
+
+  const callAction = async (path: string, successMsg: string) => {
+    try {
+      await dataProvider.update("payroll-runs", {
+        id: `${run.id}/${path}`,
+        data: {},
+        previousData: run,
+      });
+      notify(successMsg, { type: "success" });
+      onChange();
+      refresh();
+    } catch (e: any) {
+      notify(`Action failed: ${e?.message ?? "unknown"}`, { type: "error" });
+    }
+  };
+
+  const deleteRun = async () => {
+    if (!window.confirm(`Delete payroll run for ${run.period}?`)) return;
+    try {
+      await dataProvider.delete("payroll-runs", { id: run.id, previousData: run });
+      notify("Payroll run deleted", { type: "success" });
+      redirect("/payroll-runs");
+    } catch (e: any) {
+      notify(`Delete failed: ${e?.message ?? "unknown"}`, { type: "error" });
+    }
+  };
+
+  return (
+    <Stack direction="row" spacing={1} mb={2}>
+      {run.status === "DRAFT" && (
+        <>
+          <Button variant="contained" color="primary" onClick={() => callAction("approve", "Approved")}>
+            Approve
+          </Button>
+          <Button color="error" onClick={deleteRun}>Delete</Button>
+        </>
+      )}
+      {run.status === "APPROVED" && (
+        <>
+          <Button onClick={() => callAction("unapprove", "Reverted to DRAFT")}>Un-approve</Button>
+          <Button variant="contained" onClick={() => callAction("close", "Closed")}>Close</Button>
+        </>
+      )}
+      {admin && (run.status === "APPROVED" || run.status === "CLOSED" || run.status === "FAILED") && (
+        <Button color="error" onClick={deleteRun}>Delete</Button>
+      )}
+    </Stack>
+  );
+};
+
+export const PayrollRunShow: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { data: initial, refetch } = useGetOne("payroll-runs", { id: id! });
+  const { data: live } = usePayrollRunStatus(
+    initial?.status === "RUNNING" ? id : undefined
+  );
+  const run = (live || initial) as any;
+  const items: any[] = run?.items || [];
+  const isEditable = run?.status === "DRAFT";
+
+  if (!run) return <Box p={2}>Loading…</Box>;
+
+  return (
+    <Box p={2}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>
+        <Button startIcon={<ArrowBackIcon />} onClick={() => navigate("/payroll-runs")}>
+          Back
+        </Button>
+        <Button onClick={() => exporter(`payroll-${run.period}`, itemsExportHeaders, itemsExportLabels)(items)}>
+          Export CSV
+        </Button>
+      </Stack>
+      <PayrollRunHeader run={run} />
+      <RunActions run={run} onChange={refetch} />
+      {run.status === "RUNNING" && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Calculation in progress — this view auto-refreshes every 2 seconds.
+        </Alert>
+      )}
+      <Datagrid
+        data={items}
+        total={items.length}
+        bulkActionButtons={false}
+        rowClick={isEditable ? (recordId: Identifier) => `/payroll-items/${recordId}` : false}
+        sort={{ field: "internalId", order: "ASC" }}
+        isRowSelectable={() => false}
+      >
+        <TextField source="internalId" label="ID" />
+        <TextField source="firstName" label="First Name" />
+        <TextField source="lastName" label="Last Name" />
+        <TextField source="clientName" label="Client" />
+        <TextField source="modality" />
+        <NumberField source="baseSalary" label="Base" />
+        <NumberField source="proportionalSalary" label="Proportional" />
+        <NumberField source="billableHoursInMonth" label="Billable Hrs" />
+        <NumberField source="overtimeHours" label="OT Hrs" />
+        <NumberField source="overtimeAmount" label="OT $" />
+        <NumberField source="reimbursementsAmount" label="Reimb" />
+        <NumberField source="vacationCashout" label="Vacation" />
+        <NumberField source="hardwareClawback" label="HW Clawback" />
+        <NumberField source="adjustment" label="Adjustment" />
+        <NumberField source="previousBalance" label="Prev Bal" />
+        <NumberField source="totalAmount" label="Total" />
+        <TextField source="notes" />
+        <TextField source="calculationError" label="Error" />
+      </Datagrid>
+    </Box>
+  );
+};
+
+// ---------- Per-item edit (adjustment + previousBalance + notes) ---------------------------------
+
+export const PayrollItemEdit: React.FC = () => {
+  return (
+    <Edit redirect={(_resource?: string, _id?: Identifier, data?: Partial<RaRecord>) =>
+      data?.payrollRunId ? `payroll-runs/${data.payrollRunId}/show` : "payroll-runs"
+    }>
+      <SimpleForm>
+        <TextField source="internalId" />
+        <TextField source="firstName" />
+        <TextField source="lastName" />
+        <NumberInput source="adjustment" />
+        <NumberInput source="previousBalance" />
+        <TextInput source="notes" multiline fullWidth />
+      </SimpleForm>
+    </Edit>
+  );
+};

--- a/src/payrollRuns.tsx
+++ b/src/payrollRuns.tsx
@@ -101,14 +101,26 @@ const TriggerDialog: React.FC<{
         <Stack spacing={2} mt={1}>
           <Stack direction="row" spacing={2}>
             <FormControl fullWidth>
-              <InputLabel>Year</InputLabel>
-              <Select label="Year" value={year} onChange={e => setYear(Number(e.target.value))}>
+              <InputLabel id="payroll-year-label">Year</InputLabel>
+              <Select
+                labelId="payroll-year-label"
+                id="payroll-year"
+                label="Year"
+                value={year}
+                onChange={e => setYear(Number(e.target.value))}
+              >
                 {yearOptions.map(y => <MenuItem key={y} value={y}>{y}</MenuItem>)}
               </Select>
             </FormControl>
             <FormControl fullWidth>
-              <InputLabel>Month</InputLabel>
-              <Select label="Month" value={month} onChange={e => setMonth(Number(e.target.value))}>
+              <InputLabel id="payroll-month-label">Month</InputLabel>
+              <Select
+                labelId="payroll-month-label"
+                id="payroll-month"
+                label="Month"
+                value={month}
+                onChange={e => setMonth(Number(e.target.value))}
+              >
                 {MONTHS.map((name, idx) => <MenuItem key={idx} value={idx + 1}>{name}</MenuItem>)}
               </Select>
             </FormControl>
@@ -343,15 +355,18 @@ const RunActions: React.FC<{ run: any; onChange: () => void }> = ({ run, onChang
     }
   };
 
+  // Mirrors RowActions.canDelete in the list: DRAFT/FAILED are deletable by anyone,
+  // APPROVED/CLOSED only by admin. Keep the two screens aligned so users don't lose
+  // the ability to delete after navigating into a run.
+  const canDelete = run.status === "DRAFT" || run.status === "FAILED"
+    || (admin && (run.status === "APPROVED" || run.status === "CLOSED"));
+
   return (
     <Stack direction="row" spacing={1} mb={2}>
       {run.status === "DRAFT" && (
-        <>
-          <Button variant="contained" color="primary" onClick={() => callAction("approve", "Approved")}>
-            Approve
-          </Button>
-          <Button color="error" onClick={deleteRun}>Delete</Button>
-        </>
+        <Button variant="contained" color="primary" onClick={() => callAction("approve", "Approved")}>
+          Approve
+        </Button>
       )}
       {run.status === "APPROVED" && (
         <>
@@ -359,7 +374,7 @@ const RunActions: React.FC<{ run: any; onChange: () => void }> = ({ run, onChang
           <Button variant="contained" onClick={() => callAction("close", "Closed")}>Close</Button>
         </>
       )}
-      {admin && (run.status === "APPROVED" || run.status === "CLOSED" || run.status === "FAILED") && (
+      {canDelete && (
         <Button color="error" onClick={deleteRun}>Delete</Button>
       )}
     </Stack>
@@ -435,7 +450,7 @@ export const PayrollRunShow: React.FC = () => {
 export const PayrollItemEdit: React.FC = () => {
   return (
     <Edit redirect={(_resource?: string, _id?: Identifier, data?: Partial<RaRecord>) =>
-      data?.payrollRunId ? `payroll-runs/${data.payrollRunId}/show` : "payroll-runs"
+      data?.payrollRunId ? `/payroll-runs/${data.payrollRunId}/show` : "/payroll-runs"
     }>
       <SimpleForm>
         <TextField source="internalId" />

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -49,6 +49,7 @@ import { SkillsList, SkillsEdit, SkillsCreate } from "./skills";
 import { BenefitsList, BenefitsEdit, BenefitsCreate } from "./benefits";
 import { EducationLevelsList, EducationLevelsEdit, EducationLevelsCreate } from "./educationLevels";
 import { FeedbackSummaryView } from "./feedbackSummary";
+import { PayrollRunsList, PayrollRunShow, PayrollItemEdit } from "./payrollRuns";
 
 type Resource =
   | React.ComponentType<any>
@@ -294,5 +295,20 @@ export const resourceMap: {
     create: EducationLevelsCreate,
     show: undefined,
     recordRepresentation: (record: { name: string }) => `${record.name}`,
+  },
+  {
+    entity: "payroll-runs",
+    list: PayrollRunsList,
+    show: PayrollRunShow,
+    edit: undefined,
+    create: undefined,
+    recordRepresentation: (record: { period: string }) => `${record.period}`,
+  },
+  {
+    entity: "payroll-items",
+    list: undefined,
+    edit: PayrollItemEdit,
+    create: undefined,
+    show: undefined,
   }
 ];


### PR DESCRIPTION
## Summary

Frontend for the new `entropay-employees` Payroll module ([entropay-employees#482](https://github.com/entropy-code/entropay-employees/pull/482)). ADMIN/HR selects year + month, clicks **Run Payroll**, and the backend kicks off an async run. A polling hook checks status every 2s while the run is `RUNNING` and stops once it transitions to `DRAFT` / `FAILED`.

Today every entropista is paid in USD, so the dialog only collects year + month — no FX rate field. If multi-currency triggers are added on the backend, the dialog would grow an FX input here.

## Changes

- `src/payrollRuns.tsx`
  - `PayrollRunsList`: year + month selector, **Run Payroll** dialog, Datagrid of previous runs with status, total, triggered-by, completed-at, recalculate / delete actions.
  - `PayrollRunShow`: header banner with formatted period (e.g. "Payroll — May 2026") and USD-formatted total, items Datagrid (employee, contract, modality, base, billable hours, overtime, reimbursements, vacation cashout, hardware clawback, adjustment, previous balance, total — all money columns formatted as USD), **Back** + **Export CSV** in a single row, run actions (Approve / Close / Unapprove / Delete with admin-override on APPROVED/CLOSED — delete on DRAFT/FAILED open to everyone).
  - `PayrollItemEdit`: only `adjustment`, `previousBalance`, `notes` editable; backend rejects edits on non-DRAFT runs. Redirects back to the parent run's show page with an absolute path.
- `src/hooks/usePayrollRunStatus.ts` — 2s `setInterval` polling, stops when status leaves `RUNNING`, cleans up on unmount.
- `src/resources.ts` — registers `payroll-runs` (list + show) and `payroll-items` (edit only).
- `src/components/layout/CustomMenu.tsx` — `PaymentsIcon` for the `payroll-runs` menu entry.

The permissions and menu entry themselves come from `V87.0__DDL_create_payroll_run_tables.sql` in the backend PR; users need to log out + back in (or clear `localStorage.config`) once that migration runs to pick them up.

## Test plan

- [x] `npm run ts-check` passes.
- [ ] As ADMIN: **Payroll** appears in the left menu.
- [ ] Click **Run Payroll** → select May 2026 → trigger → run row appears with status `RUNNING` → polls every 2s → flips to `DRAFT` when done.
- [ ] Open a `DRAFT` run → edit an item's `adjustment` / `notes` → totals refresh, redirect drops you back at `/payroll-runs/{id}/show` (not a nested route).
- [ ] **Approve** → buttons reflect new state. **Unapprove** → back to DRAFT.
- [ ] On a `FAILED` run, the **Delete** button is visible to non-admins from both the list and the show page (alignment fix).
- [ ] **Export CSV** → file downloads with expected columns.
- [ ] As ADMIN, delete an APPROVED run → succeeds. As HR_DIRECTOR, same action → 409.

— claude-opus-4-7