### PR TITLE
[admin-ui] Source profile vacation days from backend to fix list/profile mismatch

### DIFF
--- a/src/components/EmployeeProfileHeader.tsx
+++ b/src/components/EmployeeProfileHeader.tsx
@@ -9,10 +9,6 @@ import { ContentCopy } from "@mui/icons-material";
 import { useTheme } from "@mui/material/styles";
 import { HasPermissions } from "./layout/CustomActions";
 
-interface EmployeeProfileHeaderProps {
-  vacationAvailableDays: number;
-}
-
 // Shared styles
 const metricBoxSx: SxProps<Theme> = {
   height: 80,
@@ -64,9 +60,7 @@ const MetricBox: React.FC<MetricBoxProps> = ({ label, value, minWidth = 100, val
   </Box>
 );
 
-export const EmployeeProfileHeader: React.FC<EmployeeProfileHeaderProps> = ({
-  vacationAvailableDays,
-}) => {
+export const EmployeeProfileHeader: React.FC = () => {
   const { palette } = useTheme();
   const [locale] = useLocaleState();
 
@@ -209,11 +203,16 @@ export const EmployeeProfileHeader: React.FC<EmployeeProfileHeaderProps> = ({
         />
       </Box>
 
-      {/* Vacation Days */}
-      <MetricBox
-        label="Vacation"
-        value={`${vacationAvailableDays} Days`}
-        minWidth={120}
+      {/* Vacation Days — sourced directly from the backend (single source of truth) */}
+      <FunctionField
+        label=""
+        render={(record) => (
+          <MetricBox
+            label="Vacation"
+            value={`${record.availableDays ?? 0} Days`}
+            minWidth={120}
+          />
+        )}
       />
 
       {/* Edit Button */}

--- a/src/employeeProfiles.tsx
+++ b/src/employeeProfiles.tsx
@@ -83,6 +83,9 @@ export const GetVacationsAndAvailableDays = (
   const { data: vacations } = useGetManyReference("vacations", {
     target: "employeeId",
     id: suggestId ? suggestId : employeeId,
+    // Override React Admin's default 25-record page so the per-year breakdown
+    // sums every vacation record, matching the backend's availableDays.
+    pagination: { page: 1, perPage: 1000 },
   });
 
   let vacationAvailableDays = 0;
@@ -182,7 +185,7 @@ export const EmployeeProfile = () => {
       actions={<EntityViewActions entity={"employees"} />}
       emptyWhileLoading
     >
-      <EmployeeProfileHeader vacationAvailableDays={vacationAvailableDays} />
+      <EmployeeProfileHeader />
       <TabbedShowLayout>
         <Tab label="Personal Information">
           <Grid


### PR DESCRIPTION
## Problem

The available vacation days shown in the **employee profile header** ("VACATION — N Days") could differ from the **employee list card** ("Vacations: N days") for the same employee. They should always match and come from the backend.

## Root cause

Both screens use the same `credit − debit` formula, but over different record sets:

- **List card** (`employees.tsx`): uses `record.availableDays`, computed by the backend (`Employee.getAvailableVacationsDays()`) over **all** vacation records.
- **Profile header** (`employeeProfiles.tsx`): recomputed on the frontend via `useGetManyReference("vacations", ...)`, which applies React Admin's default pagination (`perPage: 25`). For employees with more than 25 vacation records, the header only summed the first page and diverged.

Employees with few records (e.g. recent hires) coincidentally matched, which is why the bug was intermittent.

## Changes

- **`EmployeeProfileHeader.tsx`**: the Vacation metric now reads `record.availableDays` directly from the backend (via `FunctionField`), the same single source of truth as the list card. Removed the redundant `vacationAvailableDays` prop and its interface.
- **`employeeProfiles.tsx`**: header rendered without the prop; raised the vacations fetch `perPage` to 1000 so the *Vacations* tab per-year breakdown and its "Available days" total also sum every record and stay consistent with the header.

## Testing

- `npm run ts-check` passes.
- Worth a manual check against the employee that originally showed the mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
