### PR TITLE
[admin-ui] Add salary to employee profile Contracts tab

### DIFF
--- a/src/components/fields/ContractSalaryField.test.tsx
+++ b/src/components/fields/ContractSalaryField.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { RecordContextProvider } from "react-admin";
+import {
+  ContractSalaryField,
+  formatPaymentSettlement,
+} from "./ContractSalaryField";
+import { IContract, IPaymentSettlement } from "../../types";
+
+const settlement = (
+  overrides: Partial<IPaymentSettlement> = {}
+): IPaymentSettlement => ({
+  id: "ps-1",
+  salary: 50000,
+  currency: "USD",
+  modality: "MONTHLY",
+  contractId: "c-1",
+  deleted: false,
+  ...overrides,
+});
+
+const contract = (
+  paymentSettlement: IPaymentSettlement[] | undefined
+): Partial<IContract> => ({
+  id: "c-1",
+  paymentSettlement: paymentSettlement as IPaymentSettlement[],
+});
+
+describe("formatPaymentSettlement", () => {
+  it("formats a monthly salary as currency + amount + modality initial", () => {
+    expect(formatPaymentSettlement(settlement())).toBe("USD 50000/m");
+  });
+
+  it("formats an hourly salary using the modality initial", () => {
+    expect(
+      formatPaymentSettlement(
+        settlement({ salary: 30, currency: "ARS", modality: "HOUR" })
+      )
+    ).toBe("ARS 30/h");
+  });
+
+  it("shows the empty indicator when the salary is null", () => {
+    expect(
+      formatPaymentSettlement(settlement({ salary: null as unknown as number }))
+    ).toBe("USD -/m");
+  });
+});
+
+describe("ContractSalaryField", () => {
+  it("shows the currency and amount for a contract with a salary", () => {
+    render(
+      <RecordContextProvider value={contract([settlement()])}>
+        <ContractSalaryField label="Salary" />
+      </RecordContextProvider>
+    );
+    expect(screen.getByText("USD 50000/m")).toBeInTheDocument();
+  });
+
+  it("shows a clear empty indicator when there is no payment settlement", () => {
+    render(
+      <RecordContextProvider value={contract([])}>
+        <ContractSalaryField label="Salary" />
+      </RecordContextProvider>
+    );
+    expect(screen.getByText("-")).toBeInTheDocument();
+  });
+
+  it("shows the empty indicator when payment settlement is missing entirely", () => {
+    render(
+      <RecordContextProvider value={contract(undefined)}>
+        <ContractSalaryField label="Salary" />
+      </RecordContextProvider>
+    );
+    expect(screen.getByText("-")).toBeInTheDocument();
+  });
+
+  it("renders one value per settlement when there are multiple currencies", () => {
+    render(
+      <RecordContextProvider
+        value={contract([
+          settlement({ id: "ps-1", salary: 50000, currency: "USD" }),
+          settlement({
+            id: "ps-2",
+            salary: 30,
+            currency: "ARS",
+            modality: "HOUR",
+          }),
+        ])}
+      >
+        <ContractSalaryField label="Salary" />
+      </RecordContextProvider>
+    );
+    expect(screen.getByText("USD 50000/m")).toBeInTheDocument();
+    expect(screen.getByText("ARS 30/h")).toBeInTheDocument();
+  });
+
+  it("shows the empty indicator inside the value when a settlement has no salary", () => {
+    render(
+      <RecordContextProvider
+        value={contract([settlement({ salary: null as unknown as number })])}
+      >
+        <ContractSalaryField label="Salary" />
+      </RecordContextProvider>
+    );
+    expect(screen.getByText("USD -/m")).toBeInTheDocument();
+  });
+});

--- a/src/components/fields/ContractSalaryField.tsx
+++ b/src/components/fields/ContractSalaryField.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { useRecordContext } from "react-admin";
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import { IContract, IPaymentSettlement } from "../../types";
+
+const EMPTY_INDICATOR = "-";
+
+/**
+ * Formats a single payment settlement as `currency amount/modalityInitial`,
+ * e.g. `USD 50000/m`. Mirrors the salary format used in the main Contracts
+ * list so the value reads the same everywhere it is shown. When the salary is
+ * not defined it renders the empty indicator (`USD -/m`).
+ */
+export const formatPaymentSettlement = (
+  settlement: IPaymentSettlement
+): string => {
+  const salary =
+    settlement.salary === null || settlement.salary === undefined
+      ? EMPTY_INDICATOR
+      : `${settlement.salary}`;
+  const modality = settlement.modality
+    ? `/${settlement.modality.charAt(0).toLowerCase()}`
+    : "";
+  return `${settlement.currency} ${salary}${modality}`;
+};
+
+interface ContractSalaryFieldProps {
+  // `label` is consumed by react-admin's Datagrid/Labeled to render the column
+  // header; it is intentionally not used inside the component itself.
+  label?: string;
+  sortable?: boolean;
+}
+
+/**
+ * Renders a contract's salary by listing each of its payment settlements as a
+ * chip. Reuses the currency + amount + modality format from the main Contracts
+ * list. Shows a clear empty indicator (`-`) when the contract has no payment
+ * settlement at all, without breaking the surrounding layout.
+ */
+export const ContractSalaryField = (_props: ContractSalaryFieldProps) => {
+  const record = useRecordContext<IContract>();
+  const settlements = record?.paymentSettlement ?? [];
+
+  if (settlements.length === 0) {
+    return <span>{EMPTY_INDICATOR}</span>;
+  }
+
+  return (
+    <Box sx={{ display: "flex", flexWrap: "wrap" }}>
+      {settlements.map((settlement) => (
+        <Chip
+          key={settlement.id}
+          label={formatPaymentSettlement(settlement)}
+          variant="outlined"
+          color="info"
+          size="small"
+          sx={{ margin: "4px" }}
+        />
+      ))}
+    </Box>
+  );
+};

--- a/src/components/fields/ContractSalaryField.tsx
+++ b/src/components/fields/ContractSalaryField.tsx
@@ -29,7 +29,6 @@ interface ContractSalaryFieldProps {
   // `label` is consumed by react-admin's Datagrid/Labeled to render the column
   // header; it is intentionally not used inside the component itself.
   label?: string;
-  sortable?: boolean;
 }
 
 /**

--- a/src/components/fields/index.ts
+++ b/src/components/fields/index.ts
@@ -1,1 +1,2 @@
 export * from "./CustomizableChipField";
+export * from "./ContractSalaryField";

--- a/src/components/forms/FormViewSections.tsx
+++ b/src/components/forms/FormViewSections.tsx
@@ -6,7 +6,6 @@ import {
   TextField,
   ReferenceField,
   ReferenceArrayField,
-  ArrayField,
   SingleFieldList,
   Labeled,
   SelectField,
@@ -14,8 +13,7 @@ import {
   ChipField
 } from "react-admin";
 import { Box, Typography, useMediaQuery } from "@mui/material";
-import { CustomizableChipField } from "../fields";
-import { IPaymentSettlement } from "../../types";
+import { ContractSalaryField } from "../fields";
 import { EducationIterator } from "./EducationSection";
 
 const FormViewSections = (config: any) => {
@@ -121,22 +119,7 @@ const FormViewSections = (config: any) => {
           config.customSections.includes("paymentSettlementSection") && (
             <Box>
             <Labeled>
-              <ArrayField source="paymentSettlement" label="Salary">
-                <SingleFieldList linkType={false}>
-                  <CustomizableChipField<IPaymentSettlement>>
-                    {(record) => {
-                      if (record) {
-                        const salary =
-                          `${record.salary}` === "null" ? "-" : `${record.salary}`;
-                        const label = `${record.currency} ${salary}/${record.modality
-                          .charAt(0)
-                          .toLowerCase()}`;
-                        return label;
-                      }
-                    }}
-                  </CustomizableChipField>
-                </SingleFieldList>
-              </ArrayField>
+              <ContractSalaryField label="Salary" />
             </Labeled>
             </Box>
           )}

--- a/src/contracts.tsx
+++ b/src/contracts.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import {
-  ArrayField,
   ChipField,
   Datagrid,
   DateField,
@@ -21,8 +20,8 @@ import {
 
 import CreateForm from "./components/forms/CreateForm";
 import EditForm from "./components/forms/EditForm";
-import { CustomizableChipField } from "./components/fields";
-import { IContract, IPaymentSettlement } from "./types";
+import { ContractSalaryField } from "./components/fields";
+import { IContract } from "./types";
 import ViewForm from "./components/forms/ViewForm";
 import QuickFilter from "./components/filters/QuickFilter";
 
@@ -171,21 +170,7 @@ export const ContractList = () => {
             record.active ? "Active" : "Inactive"
           }
         />
-        <ArrayField source="paymentSettlement" label="Salary">
-          <SingleFieldList linkType={false}>
-            <CustomizableChipField<IPaymentSettlement>>
-              {(record) => {
-                if (record) {
-                  const salary =
-                    `${record.salary}` === "null" ? "-" : `${record.salary}`;
-                  return `${record.currency} ${salary}/${record.modality
-                    .charAt(0)
-                    .toLowerCase()}`;
-                }
-              }}
-            </CustomizableChipField>
-          </SingleFieldList>
-        </ArrayField>
+        <ContractSalaryField label="Salary" />
         <DateField source="startDate" locales={locale} />
         <DateField source="endDate" locales={locale} />
         <ReferenceField source="roleId" reference="roles" link={false}>

--- a/src/employeeProfiles.tsx
+++ b/src/employeeProfiles.tsx
@@ -37,6 +37,7 @@ import { useTheme } from "@mui/material/styles";
 import { proficiencyLevel } from "./skills";
 import { engagementTypeChoices } from "./assignments";
 import { EmployeeProfileHeader } from "./components/EmployeeProfileHeader";
+import { ContractSalaryField } from "./components/fields";
 import { EducationLevelField, EducationInstitutionField, EducationDegreeField } from "./components/forms/EducationSection";
 
 const DisplayRecordCurrentId = () => {
@@ -342,6 +343,7 @@ export const EmployeeProfile = () => {
                 <ChipField source="name" />
               </ReferenceField>
               <NumberField source="hoursPerMonth" />
+              <ContractSalaryField label="Salary" />
               <ReferenceArrayField source="benefitIds" reference="benefits" label="Benefits">
                 <SingleFieldList linkType={false}>
                   <ChipField source="name" />


### PR DESCRIPTION
**Sub-card:** https://3.basecamp.com/5776473/buckets/37034902/card_tables/cards/10012782069
**Parent story:** https://3.basecamp.com/5776473/buckets/37034902/card_tables/cards/10012632575

## Summary
The Contracts tab in the employee profile (`#/employees/{id}/show` → Contracts) listed contract type, status, company, dates, role, seniority, hours, benefits and notes, but no salary — forcing reviewers to open each contract to check compensation. This adds a **Salary** value to that tab, bringing it to parity with the Assignments tab (which already shows a rate).

Frontend-only change; the salary data already comes in the contracts API response.

## What changed
- New reusable `ContractSalaryField` component (+ pure `formatPaymentSettlement` helper) in `src/components/fields/`. Renders one chip per payment settlement as `currency amount/modalityInitial` (e.g. `USD 50000/m`), and a clear `-` when the contract has no payment settlement.
- Wired it into the employee profile **Contracts tab** (`employeeProfiles.tsx`), placed alongside the existing columns (after Hours per month).
- **Deduplication:** the exact same salary-formatting logic was previously inlined in two places — the main Contracts list (`contracts.tsx`) and the contract view form (`FormViewSections.tsx`). Both now reuse the shared component, so the format stays consistent everywhere and there's a single source of truth.

## Acceptance criteria
- [x] The Contracts tab shows a **Salary** value for each contract listed.
- [x] Salary displayed with currency + amount + modality, consistent with the main Contracts list.
- [x] No salary defined → shows `-` without breaking the layout.
- [x] Salary sits naturally alongside the existing columns (no displacement).
- [x] Mirrors the Assignments tab (per-row compensation), reusing the richer currency-aware format from the main Contracts list.
- [x] Multiple settlements / currencies → one value per settlement, aligned with the main Contracts list.

## Testing
TDD with Jest + React Testing Library. New `ContractSalaryField.test.tsx` (8 tests, all passing) covers: salary present (monthly/hourly), null salary, no settlements, missing settlements, and multiple currencies. `npm run ts-check` is clean.

> ⚠️ Note: the pre-existing `App.test.tsx` fails on `main` independently of this change (`config.ts` reads `window._env_`, which is only injected at container runtime and is undefined under Jest). Verified by stashing this branch and running it on clean `main`. Not introduced here; out of scope for this ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)