### PR TITLE
[admin-ui] Show 0% margin in employee detail header instead of a dash

### DIFF
--- a/src/components/EmployeeProfileHeader.tsx
+++ b/src/components/EmployeeProfileHeader.tsx
@@ -8,6 +8,7 @@ import { Avatar, Box, Typography, SxProps, Theme, IconButton, Tooltip } from "@m
 import { ContentCopy } from "@mui/icons-material";
 import { useTheme } from "@mui/material/styles";
 import { HasPermissions } from "./layout/CustomActions";
+import { formatMargin } from "../utils/formatMargin";
 
 // Shared styles
 const metricBoxSx: SxProps<Theme> = {
@@ -167,11 +168,12 @@ export const EmployeeProfileHeader: React.FC = () => {
       <FunctionField
         label=""
         render={(record) => {
-          const marginColor = record.margin && record.margin >= 30 ? "#4caf50" : "#f44336";
+          const marginColor =
+            record.margin != null ? (record.margin >= 30 ? "#4caf50" : "#f44336") : "inherit";
           return (
             <MetricBox
               label="Margin"
-              value={record.margin ? `${record.margin}%` : "-"}
+              value={formatMargin(record.margin)}
               minWidth={100}
               valueColor={marginColor}
             />

--- a/src/utils/formatMargin.test.ts
+++ b/src/utils/formatMargin.test.ts
@@ -1,0 +1,19 @@
+import { formatMargin } from "./formatMargin";
+
+describe("formatMargin", () => {
+  it("renders a 0 margin as 0% (pass-through engagement), not the empty indicator", () => {
+    expect(formatMargin(0)).toBe("0%");
+  });
+
+  it("renders a positive margin with a percent sign", () => {
+    expect(formatMargin(45)).toBe("45%");
+  });
+
+  it("renders the empty indicator when the margin is null", () => {
+    expect(formatMargin(null)).toBe("-");
+  });
+
+  it("renders the empty indicator when the margin is undefined", () => {
+    expect(formatMargin(undefined)).toBe("-");
+  });
+});

--- a/src/utils/formatMargin.ts
+++ b/src/utils/formatMargin.ts
@@ -1,0 +1,6 @@
+// Format the margin metric for display. A margin of 0 is a real value (e.g. a pass-through
+// hourly engagement, where cost equals the billed rate), so only a null/undefined margin renders
+// the empty indicator. This matches the employee list card so the same employee never shows
+// "0%" in one view and "-" in another.
+export const formatMargin = (margin: number | null | undefined): string =>
+  margin != null ? `${margin}%` : "-";


### PR DESCRIPTION
**Parent story:** https://3.basecamp.com/5776473/buckets/37034902/card_tables/cards/10012609759
**Related:** entropay-employees#505 (backend fix that makes hourly margins real, including 0% for pass-through)

## Problem
After the backend started returning a real **0%** margin for pass-through hourly engagements, the employee **detail header** still showed a dash (`-`) while the **list card** correctly showed `0%` — the same employee, two different values.

| View | Before | After |
|---|---|---|
| List card | `0%` | `0%` |
| Detail header | `-` ❌ | `0%` ✅ |

## Root cause
The detail header (`EmployeeProfileHeader.tsx`) formatted the margin with a truthiness check — `record.margin ? \`${record.margin}%\` : "-"` — so `0` (falsy) fell through to the empty indicator. The list card (`employees.tsx`) already used `record.margin != null`, which treats `0` as a real value.

## Fix
- Align the header with the card: only `null`/`undefined` renders `-`; `0` renders `0%`. Same change applied to the margin color (null → inherited color instead of red).
- Extracted the formatting into a pure `src/utils/formatMargin.ts` helper and unit-tested it. It lives in `utils/` rather than the component because importing `EmployeeProfileHeader.tsx` into a test pulls in `@mui/icons-material`, whose barrel index breaks jest's module resolver (`Cannot find module './PlaylistPlayTwoTone'`).

## Testing
- `npm run ts-check` — clean.
- `formatMargin.test.ts` — 4 passing: `0 → "0%"`, `45 → "45%"`, `null → "-"`, `undefined → "-"`.

## Acceptance criteria (parent story)
- [x] Corrected margin appears **consistently** in the list card, the detail header, and the margin report — the detail header now matches the card for a 0% margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)